### PR TITLE
Fix Linux AppImage end-to-end (#11)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -54,33 +54,32 @@ jobs:
           if-no-files-found: error
 
   build-linux:
-    # ubuntu-22.04 jammy doesn't package the libzip CLI tools (zipcmp /
-    # zipmerge / ziptool), but libzip-dev's CMake config imports them as
-    # IMPORTED targets at find_package() time, so configure fails before
-    # we even get to compile. ubuntu-24.04 noble has libzip-tools and is
-    # what we'd ship against anyway. Trade-off: AppImages built on noble
-    # (glibc 2.39) won't run on distros older than ~Debian 13. If we
-    # need wider compat later, switch back to jammy + vendor libzip via
-    # FetchContent in libultraship.
-    runs-on: ubuntu-24.04
+    # Build on jammy (glibc 2.35) so the AppImage runs everywhere we
+    # care about: Steam Deck (Holo, glibc 2.38), Debian 12 (2.36),
+    # Fedora 38+ (2.37+), Ubuntu 22.04+. The AppImage links against
+    # the build host's glibc — it's on linuxdeploy's excludelist, not
+    # bundled — so jammy's 2.35 sets the floor. Noble (2.39) is too
+    # new; it cuts off Steam Deck.
+    #
+    # jammy's libtinyxml2-dev ships only pkg-config metadata; the
+    # cmake/Findtinyxml2.cmake shim falls back to pkg-config and
+    # builds an IMPORTED target by hand so libultraship's
+    # find_package(tinyxml2) resolves cleanly.
+    #
+    # libzip-dev on jammy AND noble exports its CMake config with
+    # zipcmp / zipmerge / ziptool as IMPORTED EXECUTABLE targets, but
+    # neither distro packages those binaries. CMake's existence check
+    # fires at find_package() time even though we never invoke the
+    # tools — stub them with `touch + chmod +x` to bypass the check.
+    runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v4
         with:
           submodules: recursive
       - name: Install build deps
         # libultraship find_package set: libzip, nlohmann_json, tinyxml2,
-        # spdlog, SDL2, GLEW.
-        #
-        # libzip CLI tools workaround: libzip-dev's installed CMake
-        # config (libzip-targets.cmake) imports libzip::zipcmp /
-        # libzip::zipmerge / libzip::ziptool as IMPORTED EXECUTABLE
-        # targets pointing at /usr/bin/{zipcmp,zipmerge,ziptool}. Ubuntu
-        # (jammy AND noble) doesn't ship those binaries in any package.
-        # CMake checks IMPORTED_LOCATION exists at find_package time and
-        # errors out — even though we don't actually need the tools at
-        # build or runtime (libultraship only links against libzip.so).
-        # Stub them in with `touch + chmod +x` so the existence check
-        # passes; nothing ever invokes them.
+        # spdlog, SDL2, GLEW. See header comment on the runner for the
+        # libzip CLI stub workaround.
         run: |
           sudo apt-get update
           sudo apt-get install -y \
@@ -89,25 +88,36 @@ jobs:
             nlohmann-json3-dev libtinyxml2-dev libspdlog-dev \
             libgl1-mesa-dev libegl1-mesa-dev \
             libxrandr-dev libxinerama-dev libxcursor-dev libxi-dev \
-            python3 imagemagick
+            python3 imagemagick file
           sudo touch /usr/bin/zipcmp /usr/bin/zipmerge /usr/bin/ziptool
           sudo chmod +x /usr/bin/zipcmp /usr/bin/zipmerge /usr/bin/ziptool
       - name: Use clang as the C/C++ compiler
-        # The codebase has been built on macOS Clang and validated there;
-        # the decomp-style shadow headers and PORT macro plumbing trip
-        # GCC's -Wint-conversion / -Wimplicit-function-declaration on
-        # va_args paths in src/sys/debug.c that Clang accepts. Switch
-        # Linux CI to Clang to match macOS toolchain. The runtime is
-        # unchanged (still libstdc++ / glibc) so AppImage compat is the
-        # same as a GCC-built binary.
+        # Match the macOS-validated Clang toolchain. GCC trips on
+        # decomp-style shadow headers (-Wint-conversion /
+        # -Wimplicit-function-declaration on va_args paths in
+        # src/sys/debug.c) that Clang accepts. Runtime is unchanged.
         run: |
           echo "CC=clang"   >> $GITHUB_ENV
           echo "CXX=clang++" >> $GITHUB_ENV
-          # appimagetool isn't packaged on apt; fetch the upstream AppImage.
+      - name: Install AppImage tooling
+        # appimagetool packs an AppDir into a runnable AppImage.
+        # linuxdeploy walks the binary's NEEDED .so list, copies the
+        # actual library files into AppDir/usr/lib/ (excluding glibc /
+        # libGL / other system-driver libs per its built-in
+        # excludelist), and patches RPATH. Without this, the AppImage
+        # links dynamically against whatever .so versions happen to be
+        # on the user's distro and fails on anything but the build host.
+        run: |
           wget -q https://github.com/AppImage/appimagetool/releases/download/continuous/appimagetool-x86_64.AppImage \
             -O /usr/local/bin/appimagetool
-          chmod +x /usr/local/bin/appimagetool
+          wget -q https://github.com/linuxdeploy/linuxdeploy/releases/download/continuous/linuxdeploy-x86_64.AppImage \
+            -O /usr/local/bin/linuxdeploy
+          chmod +x /usr/local/bin/appimagetool /usr/local/bin/linuxdeploy
       - name: Package Linux AppImage
+        # APPIMAGE_EXTRACT_AND_RUN=1 lets linuxdeploy / appimagetool
+        # run without libfuse2 (some runner images ship without it).
+        env:
+          APPIMAGE_EXTRACT_AND_RUN: "1"
         run: bash scripts/package-linux.sh
       - uses: actions/upload-artifact@v4
         with:

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2,6 +2,11 @@ cmake_minimum_required(VERSION 3.24.0 FATAL_ERROR)
 
 project(ssb64 LANGUAGES C CXX)
 
+# Pulled-in BEFORE the libultraship subdirectory so its
+# find_package(tinyxml2) sees our pkg-config-fallback shim. Required
+# for Ubuntu 22.04 jammy, where libtinyxml2-dev ships no CMake config.
+list(APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/cmake")
+
 if (CMAKE_SYSTEM_NAME STREQUAL "Darwin" OR CMAKE_SYSTEM_NAME STREQUAL "iOS")
     enable_language(OBJCXX)
     set(CMAKE_OBJCXX_FLAGS "${CMAKE_OBJCXX_FLAGS} -fobjc-arc")

--- a/cmake/Findtinyxml2.cmake
+++ b/cmake/Findtinyxml2.cmake
@@ -1,0 +1,51 @@
+# Provides the tinyxml2::tinyxml2 IMPORTED target on systems where
+# libtinyxml2-dev only ships pkg-config metadata (tinyxml2.pc) but no
+# CMake config (tinyxml2Config.cmake).
+#
+# Concretely this matters for Ubuntu 22.04 jammy, which ships
+# libtinyxml2-dev 9.0.0 with pkg-config only. Newer distros (Ubuntu
+# 24.04 noble libtinyxml2 10.x, Fedora 39+ tinyxml2 10.x+, Arch,
+# Homebrew, vcpkg) all ship a CMake config and skip the fallback.
+#
+# Strategy: Module mode runs first by default, so this file is
+# consulted before <package>Config.cmake. Try CONFIG mode explicitly
+# (cheap re-entry, can't recurse since CONFIG bypasses Module mode).
+# If that finds a config, defer to it. Otherwise fall back to
+# pkg-config and assemble an IMPORTED target by hand.
+
+find_package(tinyxml2 CONFIG QUIET)
+if(tinyxml2_FOUND)
+    return()
+endif()
+
+find_package(PkgConfig QUIET)
+if(PkgConfig_FOUND)
+    pkg_check_modules(PC_TINYXML2 QUIET tinyxml2)
+endif()
+
+find_path(tinyxml2_INCLUDE_DIR
+    NAMES tinyxml2.h
+    HINTS ${PC_TINYXML2_INCLUDE_DIRS}
+)
+find_library(tinyxml2_LIBRARY
+    NAMES tinyxml2
+    HINTS ${PC_TINYXML2_LIBRARY_DIRS}
+)
+
+set(tinyxml2_VERSION ${PC_TINYXML2_VERSION})
+
+include(FindPackageHandleStandardArgs)
+find_package_handle_standard_args(tinyxml2
+    REQUIRED_VARS tinyxml2_LIBRARY tinyxml2_INCLUDE_DIR
+    VERSION_VAR tinyxml2_VERSION
+)
+
+if(tinyxml2_FOUND AND NOT TARGET tinyxml2::tinyxml2)
+    add_library(tinyxml2::tinyxml2 UNKNOWN IMPORTED)
+    set_target_properties(tinyxml2::tinyxml2 PROPERTIES
+        IMPORTED_LOCATION "${tinyxml2_LIBRARY}"
+        INTERFACE_INCLUDE_DIRECTORIES "${tinyxml2_INCLUDE_DIR}"
+    )
+endif()
+
+mark_as_advanced(tinyxml2_INCLUDE_DIR tinyxml2_LIBRARY)

--- a/port/first_run.cpp
+++ b/port/first_run.cpp
@@ -56,6 +56,25 @@ std::string FindExisting(const std::vector<std::string>& candidates) {
     return {};
 }
 
+// Resolve the directory containing this process's executable.
+//
+// Ship::Context::GetAppBundlePath() on Linux + NON_PORTABLE returns
+// the literal CMAKE_INSTALL_PREFIX (default /usr/local), which is
+// wrong for AppImages (binary actually lives at
+// /tmp/.mount_XYZ/usr/bin/) and for any non-prefix install. Use
+// /proc/self/exe to get the real directory and fall back to the
+// upstream API only if the readlink fails.
+std::string RealAppBundlePath() {
+#if defined(__linux__)
+    std::error_code ec;
+    fs::path exe = fs::read_symlink("/proc/self/exe", ec);
+    if (!ec && !exe.empty()) {
+        return exe.parent_path().string();
+    }
+#endif
+    return Ship::Context::GetAppBundlePath();
+}
+
 // Locate the torch binary. Tries (in priority order):
 //   1. Next to ssb64 binary (shipped layout — Win/Linux: same dir; macOS:
 //      Contents/MacOS/torch).
@@ -63,7 +82,7 @@ std::string FindExisting(const std::vector<std::string>& candidates) {
 //   3. Dev build location (build/TorchExternal/src/TorchExternal-build/torch).
 //   4. PATH lookup via the bare name (last-resort).
 std::string FindTorchBinary() {
-    const std::string app = Ship::Context::GetAppBundlePath();
+    const std::string app = RealAppBundlePath();
     std::vector<std::string> candidates = {
         app + "/torch",
         app + "/torch.exe",
@@ -91,11 +110,13 @@ std::string FindTorchBinary() {
 // enumerates all yamls/us/*.yml extraction recipes). Torch must be invoked
 // with this directory as cwd.
 std::string FindTorchConfigDir() {
-    const std::string app = Ship::Context::GetAppBundlePath();
+    const std::string app = RealAppBundlePath();
     std::vector<std::string> candidates = {
-        app,                        // shipped: macOS Resources, Win/Linux exe-dir
-        app + "/..",                // dev: build/ssb64 → project root
-        ".",                        // last-ditch cwd
+        app,                                  // macOS Resources, Windows exe-dir
+        app + "/../share/BattleShip",         // Linux AppImage usr/bin → usr/share/BattleShip;
+                                              // /usr install bin → share/BattleShip
+        app + "/..",                          // dev: build/ssb64 → project root
+        ".",                                  // last-ditch cwd
     };
     for (const auto& dir : candidates) {
         if (fs::exists(dir + "/config.yml") && fs::exists(dir + "/yamls/us")) {
@@ -111,7 +132,7 @@ std::string FindTorchConfigDir() {
 //   3. cwd / project  — dev workflow.
 std::string FindBaseRom() {
     const std::string appData = Ship::Context::GetAppDirectoryPath();
-    const std::string bundle = Ship::Context::GetAppBundlePath();
+    const std::string bundle = RealAppBundlePath();
     std::vector<std::string> candidates;
     for (const auto& base : {appData, bundle, bundle + "/..", std::string(".")}) {
         for (const char* ext : {"z64", "n64", "v64"}) {
@@ -159,9 +180,50 @@ bool ExtractAssetsIfNeeded(const std::string& target_o2r_path, bool silent) {
     }
     port_log("first_run: torch config dir -> %s\n", cfgDir.c_str());
 
-    // Compose: cd "<cfgDir>" && "<torch>" o2r "<rom>"
-    // Torch reads config.yml from cwd and emits BattleShip.o2r in cwd
-    // (the `binary:` key in config.yml is just "BattleShip.o2r").
+    // Stage a writable copy of config.yml + yamls/ in the app-data dir
+    // and run torch from there. The bundled config dir is read-only in
+    // every shipped layout (AppImage squashfs, macOS .app/Contents/...,
+    // /usr/local install). Torch reads config from cwd and writes
+    // BattleShip.o2r + a version file + side-artifact dirs (src/assets,
+    // include/assets, modding) into cwd. On a read-only cwd those
+    // writes fail mid-pipeline, but torch reports a successful exit
+    // anyway — surfaces as "torch reported success but BattleShip.o2r
+    // is missing." Staging into the app-data dir gives torch a
+    // writable scratch space and lands BattleShip.o2r right next to
+    // the target path so we can rename within the same filesystem.
+    fs::create_directories(fs::path(target_o2r_path).parent_path());
+    const fs::path workDir =
+        fs::path(target_o2r_path).parent_path() / "torch-work";
+    std::error_code ec;
+    fs::remove_all(workDir, ec);
+    ec.clear();
+    fs::create_directories(workDir, ec);
+    if (ec) {
+        port_log("first_run: ERROR could not create %s: %s\n",
+                 workDir.string().c_str(), ec.message().c_str());
+        return false;
+    }
+    fs::copy_file(fs::path(cfgDir) / "config.yml",
+                  workDir / "config.yml",
+                  fs::copy_options::overwrite_existing, ec);
+    if (ec) {
+        port_log("first_run: ERROR could not stage config.yml: %s\n",
+                 ec.message().c_str());
+        return false;
+    }
+    fs::copy(fs::path(cfgDir) / "yamls", workDir / "yamls",
+             fs::copy_options::recursive |
+                 fs::copy_options::overwrite_existing,
+             ec);
+    if (ec) {
+        port_log("first_run: ERROR could not stage yamls/: %s\n",
+                 ec.message().c_str());
+        return false;
+    }
+    const std::string runDir = workDir.string();
+    port_log("first_run: torch work dir -> %s\n", runDir.c_str());
+
+    // Compose: cd "<runDir>" && "<torch>" o2r "<rom>"
     //
     // Append the ssb64.log path to the child's stdio. Our parent process
     // has spdlog and assorted file descriptors open; if the child writes
@@ -173,11 +235,11 @@ bool ExtractAssetsIfNeeded(const std::string& target_o2r_path, bool silent) {
     fs::create_directories(fs::path(logPath).parent_path());
     std::string cmd;
 #ifdef _WIN32
-    cmd = "cmd /C \"cd /D " + ShellQuote(cfgDir) + " && " +
+    cmd = "cmd /C \"cd /D " + ShellQuote(runDir) + " && " +
           ShellQuote(torch) + " o2r " + ShellQuote(rom) +
           " > " + ShellQuote(logPath) + " 2>&1\"";
 #else
-    cmd = "cd " + ShellQuote(cfgDir) + " && " +
+    cmd = "cd " + ShellQuote(runDir) + " && " +
           ShellQuote(torch) + " o2r " + ShellQuote(rom) +
           " > " + ShellQuote(logPath) + " 2>&1";
 #endif
@@ -199,20 +261,17 @@ bool ExtractAssetsIfNeeded(const std::string& target_o2r_path, bool silent) {
         return false;
     }
 
-    const std::string emitted = cfgDir + "/BattleShip.o2r";
+    const std::string emitted = (workDir / "BattleShip.o2r").string();
     if (!fs::exists(emitted)) {
         port_log("first_run: ERROR torch reported success but %s is missing\n",
                  emitted.c_str());
         return false;
     }
 
-    // Move (or copy + remove if move-across-filesystems fails) into the
-    // target app-data path.
-    fs::create_directories(fs::path(target_o2r_path).parent_path());
-    std::error_code ec;
+    // Move into the target app-data path. The work dir lives under the
+    // same parent as target_o2r_path so this is an intra-fs rename.
     fs::rename(emitted, target_o2r_path, ec);
     if (ec) {
-        // Cross-filesystem rename failed — fall back to copy + delete.
         ec.clear();
         fs::copy_file(emitted, target_o2r_path,
                       fs::copy_options::overwrite_existing, ec);
@@ -222,8 +281,10 @@ bool ExtractAssetsIfNeeded(const std::string& target_o2r_path, bool silent) {
                      ec.message().c_str());
             return false;
         }
-        fs::remove(emitted, ec);
     }
+    // Drop the staging dir (config.yml + yamls/ + any torch
+    // side-artifacts). Best-effort — leaving it behind isn't fatal.
+    fs::remove_all(workDir, ec);
 
     port_log("first_run: extracted BattleShip.o2r -> %s\n",
              target_o2r_path.c_str());

--- a/port/native_dialog.cpp
+++ b/port/native_dialog.cpp
@@ -88,10 +88,24 @@ std::string OpenFileDialog(const std::string& title,
     return RunAndCaptureFirstLine(cmd);
 
 #elif defined(__linux__) || defined(__unix__)
+    // Inside an AppImage, our AppRun sets LD_LIBRARY_PATH to the
+    // bundled $APPDIR/usr/lib so the game's own .so deps resolve
+    // against versions matching the build host. That same path
+    // poisons system tools like zenity / kdialog which load the
+    // distro's libssl/libcrypto/libcurl/etc. — the bundled
+    // libcrypto.so.3 from the build host is older than the system
+    // libssl.so.3 expects, so the dialog dies with `version
+    // OPENSSL_3.X.0 not found` before it can show a window. Strip
+    // LD_LIBRARY_PATH (and LD_PRELOAD, for symmetry) on the spawned
+    // dialog process so it only sees the system loader path.
+    constexpr const char* env_strip =
+        "env -u LD_LIBRARY_PATH -u LD_PRELOAD ";
+
     // zenity first.
     {
-        std::string cmd = "zenity --file-selection --title=" +
-                          ShellSingleQuote(title);
+        std::string cmd = env_strip;
+        cmd += "zenity --file-selection --title=" +
+               ShellSingleQuote(title);
         if (!extensions.empty()) {
             std::string filter = "--file-filter=";
             for (size_t i = 0; i < extensions.size(); ++i) {
@@ -105,7 +119,8 @@ std::string OpenFileDialog(const std::string& title,
     }
     // Fall back to kdialog if zenity isn't installed or returned empty.
     {
-        std::string cmd = "kdialog --getopenfilename ~ ";
+        std::string cmd = env_strip;
+        cmd += "kdialog --getopenfilename ~ ";
         if (!extensions.empty()) {
             std::string filter;
             for (size_t i = 0; i < extensions.size(); ++i) {

--- a/scripts/package-linux.sh
+++ b/scripts/package-linux.sh
@@ -20,11 +20,18 @@
 # BattleShip.o2r is NOT bundled — extracted on first launch via the ImGui
 # wizard from the user's ROM into the app-data dir.
 #
-# Requires: appimagetool in PATH. linuxdeploy is optional but useful.
-#   appimagetool: https://github.com/AppImage/AppImageKit/releases
+# Requires:
+#   appimagetool — packs the AppDir into a runnable AppImage.
+#     https://github.com/AppImage/appimagetool/releases
+#   linuxdeploy  — walks the binary's NEEDED .so list and copies the
+#     actual library files into AppDir/usr/lib/ so the AppImage runs
+#     on distros that don't have the build host's exact .so versions.
+#     https://github.com/linuxdeploy/linuxdeploy/releases
 #
-# If appimagetool isn't available, the script still produces the
-# AppDir tree under dist/ so you can package it later.
+# If linuxdeploy isn't in PATH the script warns and skips library
+# bundling — the resulting AppImage will only run on systems whose
+# .so versions match the build host. If appimagetool isn't available,
+# the script still produces the AppDir under dist/ for manual packing.
 
 set -euo pipefail
 
@@ -88,18 +95,12 @@ cp "$ROOT/gamecontrollerdb.txt" "$APPDIR/usr/share/$APP_NAME/gamecontrollerdb.tx
 cp "$ROOT/config.yml" "$APPDIR/usr/share/$APP_NAME/config.yml"
 cp "$ROOT/yamls/us/"*.yml "$APPDIR/usr/share/$APP_NAME/yamls/us/"
 
-# ── 5. AppRun + .desktop + icon ──
-# AppRun is what the AppImage calls when launched. Switch cwd to the
-# data dir so torch can find config.yml + yamls/, then exec the binary.
-cat > "$APPDIR/AppRun" <<EOF
-#!/bin/sh
-HERE="\$(dirname "\$(readlink -f "\${0}")")"
-export PATH="\$HERE/usr/bin:\$PATH"
-cd "\$HERE/usr/share/$APP_NAME" || exit 1
-exec "\$HERE/usr/bin/$APP_NAME" "\$@"
-EOF
-chmod +x "$APPDIR/AppRun"
-
+# ── 5. .desktop + icon (AppRun written after linuxdeploy) ──
+# linuxdeploy reads .desktop + icon from the AppDir, so they have to
+# exist before we invoke it. AppRun is written *after* linuxdeploy
+# runs because linuxdeploy will overwrite whatever AppRun is there
+# with its own wrapper; we want our cd-to-data-dir + LD_LIBRARY_PATH
+# version to be the final one.
 cat > "$APPDIR/$APP_NAME.desktop" <<EOF
 [Desktop Entry]
 Type=Application
@@ -143,7 +144,47 @@ else
 fi
 cp "$ICON_SRC" "$ICON_HI512"
 
-# ── 6. Pack into AppImage if appimagetool is available ──
+# ── 6. Bundle .so dependencies via linuxdeploy ──
+# linuxdeploy populates AppDir/usr/lib/ with the binary's NEEDED libs
+# (minus glibc / libGL / other system-driver libs on its excludelist).
+# Without this, the AppImage links dynamically against whatever .so
+# versions happen to be on the user's distro and fails on anything
+# but the exact build host's distro+version.
+if command -v linuxdeploy >/dev/null 2>&1; then
+    step "Bundling shared libraries via linuxdeploy"
+    linuxdeploy \
+        --appdir "$APPDIR" \
+        --executable "$APPDIR/usr/bin/$APP_NAME" \
+        --executable "$APPDIR/usr/bin/torch" \
+        --desktop-file "$APPDIR/$APP_NAME.desktop" \
+        --icon-file "$APPDIR/$APP_NAME.png"
+else
+    printf '\n\033[33m! linuxdeploy not in PATH — skipping .so bundling.\033[0m\n'
+    printf '   The AppImage will only run on systems with matching .so versions.\n'
+    printf '   Install from https://github.com/linuxdeploy/linuxdeploy/releases\n'
+fi
+
+# ── 7. AppRun ──
+# Linuxdeploy makes AppRun a *symlink* to usr/bin/BattleShip and
+# expects users to embed their AppRun-equivalent logic (env, cwd) in
+# the binary's launch path. Our binary doesn't do that, and torch
+# needs cwd=usr/share/BattleShip to find config.yml + yamls/. Replace
+# the symlink (rm first — `cat >` follows symlinks and would clobber
+# the game binary at usr/bin/BattleShip) with a shell script that
+# sets LD_LIBRARY_PATH for the bundled libs, cd's into the data dir,
+# then execs the binary.
+rm -f "$APPDIR/AppRun"
+cat > "$APPDIR/AppRun" <<EOF
+#!/bin/sh
+HERE="\$(dirname "\$(readlink -f "\${0}")")"
+export PATH="\$HERE/usr/bin:\$PATH"
+export LD_LIBRARY_PATH="\$HERE/usr/lib\${LD_LIBRARY_PATH:+:\$LD_LIBRARY_PATH}"
+cd "\$HERE/usr/share/$APP_NAME" || exit 1
+exec "\$HERE/usr/bin/$APP_NAME" "\$@"
+EOF
+chmod +x "$APPDIR/AppRun"
+
+# ── 8. Pack into AppImage if appimagetool is available ──
 if command -v appimagetool >/dev/null 2>&1; then
     step "Packing AppImage"
     rm -f "$APPIMAGE"


### PR DESCRIPTION
## Summary

The v0.3.2 AppImage failed on every distro that didn't match the Ubuntu 24.04 build host's exact `.so` versions, and even when the shared-library issue was sidestepped, the first-run wizard's file picker hung and torch silently dropped `BattleShip.o2r` on the floor. Steam Deck (glibc 2.38) couldn't run it at all. Reproduced the full chain on a clean Fedora 43 / KDE Plasma / Wayland install.

This PR is one cohesive change touching CI, packaging, the wizard's subprocess plumbing, and AppDir-relative path resolution.

## CI / packaging

- **`ubuntu-22.04` jammy runner** (glibc 2.35 floor — covers Steam Deck, Debian 12, Fedora 38+). Noble's 2.39 cuts off Steam Deck.
- **linuxdeploy bundles `.so` deps** (libzip, libtinyxml2, libspdlog, libfmt, libSDL2, …) into `AppDir/usr/lib/` so the AppImage doesn't rely on whatever the user's distro ships. Excludelist keeps glibc / libGL / libstdc++ system-side.
- **`APPIMAGE_EXTRACT_AND_RUN=1`** in the package step — runner images inconsistently ship libfuse2.
- **`cmake/Findtinyxml2.cmake`** — pkg-config fallback for jammy, where `libtinyxml2-dev` ships only the `.pc` file. Module mode is consulted before `<package>Config.cmake`, so the shim wins on jammy and defers to CONFIG mode on noble / Fedora / Arch / Brew / vcpkg.

## `package-linux.sh`

- Run linuxdeploy after assembling the AppDir, then **`rm -f` the AppRun symlink** it leaves behind before writing our own. Without the rm, `cat > AppRun` *follows the symlink* and clobbers `usr/bin/BattleShip` with a 241-byte shell script.
- AppRun exports `LD_LIBRARY_PATH=$HERE/usr/lib` alongside the existing cd-into-data-dir + PATH setup so the bundled libs are actually used.

## Wizard / first-run

- **`native_dialog`**: `env -u LD_LIBRARY_PATH -u LD_PRELOAD` prefix on zenity / kdialog popen commands. Inheriting the AppDir's bundled `libcrypto.so.3` into a system tool that loads the distro's `libssl.so.3` produces "version `OPENSSL_3.X.0` not found" before the dialog can draw. Strip those vars for the spawned tool; torch keeps inheriting them since it's our own bundled binary.
- **`first_run`**: stage `config.yml` + `yamls/` into `<appdata>/torch-work/` and run torch from there. The bundled config dir is read-only in every shipped layout (AppImage squashfs FUSE mount, macOS `.app` Resources, `/usr/local` install). Torch reads from cwd but also *writes* `BattleShip.o2r` + a version file + side-artifact dirs there; on read-only cwd those writes silently fail mid-pipeline while torch reports a successful exit. Stage to a writable scratch dir on the same filesystem as the final target so the rename is intra-fs.
- **`first_run`**: `RealAppBundlePath()` helper uses `readlink("/proc/self/exe")` on Linux instead of trusting `Ship::Context::GetAppBundlePath()`, which returns hardcoded `CMAKE_INSTALL_PREFIX` (default `/usr/local`) under `NON_PORTABLE` — completely wrong inside an AppImage. Updates `FindTorchBinary` / `FindTorchConfigDir` / `FindBaseRom` to use it, plus adds the AppImage `usr/share/<APP>` location to the config-dir candidate list.

## Test plan

- [x] Built locally on Fedora 43 (glibc 2.42); ran via AppRun. Wizard launched, file picker opened, ROM selected, torch staged into `torch-work/`, `BattleShip.o2r` landed in `~/.local/share/BattleShip/`, game booted to attract demo, ran 497 frames, clean exit.
- [ ] CI artifact runs on Fedora 43 (jammy build host)
- [ ] CI artifact runs on Steam Deck (glibc 2.38 — primary motivation for jammy)
- [ ] CI artifact runs on Ubuntu 22.04+ (build host distro)

Closes #11.

🤖 Generated with [Claude Code](https://claude.com/claude-code)