### PR TITLE
Feature: disable tap jump

### DIFF
--- a/src/ft/ftcommon/ftcommonkneebend.c
+++ b/src/ft/ftcommon/ftcommonkneebend.c
@@ -1,4 +1,7 @@
 #include <ft/fighter.h>
+#include <stdint.h>
+
+extern int32_t CVarGetInteger(const char* name, int32_t defaultValue);
 
 // // // // // // // // // // // //
 //                               //
@@ -86,7 +89,10 @@ sb32 ftCommonKneeBendCheckButtonTap(FTStruct *fp)
 // 0x8013F474
 s32 ftCommonKneeBendGetInputTypeCommon(FTStruct *fp)
 {
-    if ((fp->input.pl.stick_range.y >= FTCOMMON_KNEEBEND_STICK_RANGE_MIN) && (fp->tap_stick_y <= FTCOMMON_KNEEBEND_BUFFER_TICS_MAX))
+    char cvarName[32];
+    sprintf(cvarName, "gDisableTapJump_P%d", fp->player + 1);
+
+    if (!CVarGetInteger(cvarName, 0) && (fp->input.pl.stick_range.y >= FTCOMMON_KNEEBEND_STICK_RANGE_MIN) && (fp->tap_stick_y <= FTCOMMON_KNEEBEND_BUFFER_TICS_MAX))
     {
         return FTCOMMON_KNEEBEND_INPUT_TYPE_STICK;
     }
@@ -121,7 +127,10 @@ sb32 ftCommonKneeBendCheckInterruptCommon(GObj *fighter_gobj)
 // 0x8013F53C
 s32 ftCommonKneeBendGetInputTypeRun(FTStruct *fp)
 {
-    if ((fp->input.pl.stick_range.y > FTCOMMON_KNEEBEND_RUN_STICK_RANGE_MIN) && (fp->tap_stick_y <= FTCOMMON_KNEEBEND_BUFFER_TICS_MAX))
+    char cvarName[32];
+    sprintf(cvarName, "gDisableTapJump_P%d", fp->player + 1);
+
+    if (!CVarGetInteger(cvarName, 0) && (fp->input.pl.stick_range.y > FTCOMMON_KNEEBEND_RUN_STICK_RANGE_MIN) && (fp->tap_stick_y <= FTCOMMON_KNEEBEND_BUFFER_TICS_MAX))
     {
         return FTCOMMON_KNEEBEND_INPUT_TYPE_STICK;
     }


### PR DESCRIPTION
<img width="640" height="480" alt="Screenshot_20260430_134349" src="https://github.com/user-attachments/assets/720682cd-693d-456b-9a89-a62457bd757a" /><br>

Adds an option in the controller configuration menu to disable tap jump on a per-port basis. Tested on multiple ports.