### PR TITLE
Drop hardcoded VS 2022 / v143 from Windows build docs

### DIFF
--- a/docs/BUILDING.md
+++ b/docs/BUILDING.md
@@ -30,15 +30,16 @@ Asset extraction requirements:
 ## Windows
 
 Requires:
-- Visual Studio 2022 with Desktop development with C++
-- MSVC v143
+- Visual Studio 2022 or newer with Desktop development with C++
 - a Windows SDK
 
 Configure:
 
 ```powershell
-& 'C:\Program Files\CMake\bin\cmake.exe' -S . -B "build/x64" -G "Visual Studio 17 2022" -T v143 -A x64
+& 'C:\Program Files\CMake\bin\cmake.exe' -S . -B "build/x64" -A x64
 ```
+
+CMake auto-detects the newest installed Visual Studio and its default toolset. If you need to pin a specific generator/toolset (e.g. on a CI runner with multiple installs), pass `-G "Visual Studio 17 2022" -T v143` explicitly.
 
 Build:
 

--- a/docs/build_and_tooling.md
+++ b/docs/build_and_tooling.md
@@ -5,7 +5,7 @@
 - libultraship and Torch are git submodules
 - MSVC on Windows, Apple Clang on macOS, GCC/Clang on Linux
 - The decomp's original MIPS toolchain (IDO 7.1) is NOT used for the port
-  - **Windows**: `& 'C:\Program Files\CMake\bin\cmake' -S . -B "build/x64" -G "Visual Studio 17 2022" -T v143 -A x64`
+  - **Windows**: `& 'C:\Program Files\CMake\bin\cmake' -S . -B "build/x64" -A x64` (CMake auto-picks the newest installed Visual Studio + default toolset)
   - **macOS / Linux**: `cmake -S . -B build-cmake -GNinja`
 - Build with:
   - `& 'C:\Program Files\CMake\bin\cmake.exe' --build .\build\x64`


### PR DESCRIPTION
## Summary

Closes #49.

The Windows configure command in `docs/BUILDING.md` and `docs/build_and_tooling.md` hardcoded `-G "Visual Studio 17 2022" -T v143`, which fails for anyone without that exact toolset installed (e.g. users on VS 2026 / v144, or with multiple VS versions where v143 isn't the default). CMake on Windows already auto-detects the newest installed Visual Studio and its default toolset, so the flags are unnecessary for the common case.

- `docs/BUILDING.md`: drop `-G`/`-T` from the configure command, drop the explicit `MSVC v143` requirement, and add a note explaining how to pin the generator/toolset for CI scenarios.
- `docs/build_and_tooling.md`: same one-line update with a parenthetical pointing at the auto-detection behavior.

Reported by @MysteriousAeon.

## Test plan

- [ ] On Windows with VS 2022 + v143 installed, `cmake -S . -B build/x64 -A x64` configures successfully.
- [ ] On Windows with only newer VS / toolset installed, configure no longer fails with "could not find any instance of Visual Studio."

🤖 Generated with [Claude Code](https://claude.com/claude-code)