### PR TITLE
Feature: translate C-Buttons as Smash/Aerial Attacks

### DIFF
--- a/port/enhancements/enhancements.cpp
+++ b/port/enhancements/enhancements.cpp
@@ -2,6 +2,30 @@
 
 #include <libultraship/bridge/consolevariablebridge.h>
 
+// Manually define the N64 button bitmasks since the C++ layer cannot see PR/os.h
+namespace {
+    // A and C-Buttons
+    constexpr unsigned short A_BUTTON  = 0x8000;
+    constexpr unsigned short U_CBUTTON = 0x0008;
+    constexpr unsigned short D_CBUTTON = 0x0004;
+    constexpr unsigned short L_CBUTTON = 0x0002;
+    constexpr unsigned short R_CBUTTON = 0x0001;
+
+    // D-Pad
+    constexpr unsigned short U_JPAD = 0x0800;
+    constexpr unsigned short D_JPAD = 0x0400;
+    constexpr unsigned short L_JPAD = 0x0200;
+    constexpr unsigned short R_JPAD = 0x0100;
+
+    // Add the CVars for D-Pad Jump
+    constexpr const char* kDPadJumpCVars[PORT_ENHANCEMENT_MAX_PLAYERS] = {
+        "gEnhancements.DPadJump.P1",
+        "gEnhancements.DPadJump.P2",
+        "gEnhancements.DPadJump.P3",
+        "gEnhancements.DPadJump.P4",
+    };
+}
+
 namespace {
 
 constexpr const char* kTapJumpCVars[PORT_ENHANCEMENT_MAX_PLAYERS] = {
@@ -20,6 +44,13 @@ enum {
     kDisplayModeHitCollisionFill = 1,
     kDisplayModeHitAttackOutline = 2,
     kDisplayModeMapCollision = 3,
+};
+
+constexpr const char* kCStickSmashCVars[PORT_ENHANCEMENT_MAX_PLAYERS] = {
+    "gEnhancements.CStickSmash.P1",
+    "gEnhancements.CStickSmash.P2",
+    "gEnhancements.CStickSmash.P3",
+    "gEnhancements.CStickSmash.P4",
 };
 
 } // namespace
@@ -43,19 +74,73 @@ extern "C" int port_enhancement_hitbox_display_override(int current_mode) {
     }
 }
 
+extern "C" void port_enhancement_c_stick_smash(int player_index, unsigned short* button_hold, unsigned short* button_tap, signed char* stick_x, signed char* stick_y, unsigned short raw_tap) {
+    if (player_index < 0 || player_index >= PORT_ENHANCEMENT_MAX_PLAYERS) return;
+    if (!CVarGetInteger(kCStickSmashCVars[player_index], 0)) return;
+
+    if (*button_hold & U_CBUTTON) {
+        *button_hold &= ~U_CBUTTON;
+        *button_tap &= ~U_CBUTTON;
+        *stick_y = 80;
+        *button_hold |= A_BUTTON;
+        if (raw_tap & U_CBUTTON) *button_tap |= A_BUTTON;
+    } else if (*button_hold & D_CBUTTON) {
+        *button_hold &= ~D_CBUTTON;
+        *button_tap &= ~D_CBUTTON;
+        *stick_y = -80;
+        *button_hold |= A_BUTTON;
+        if (raw_tap & D_CBUTTON) *button_tap |= A_BUTTON;
+    } else if (*button_hold & L_CBUTTON) {
+        *button_hold &= ~L_CBUTTON;
+        *button_tap &= ~L_CBUTTON;
+        *stick_x = -80;
+        *button_hold |= A_BUTTON;
+        if (raw_tap & L_CBUTTON) *button_tap |= A_BUTTON;
+    } else if (*button_hold & R_CBUTTON) {
+        *button_hold &= ~R_CBUTTON;
+        *button_tap &= ~R_CBUTTON;
+        *stick_x = 80;
+        *button_hold |= A_BUTTON;
+        if (raw_tap & R_CBUTTON) *button_tap |= A_BUTTON;
+    }
+}
+
+extern "C" void port_enhancement_dpad_jump(int player_index, unsigned short* button_hold, unsigned short* button_tap, unsigned short raw_tap) {
+    if (player_index < 0 || player_index >= PORT_ENHANCEMENT_MAX_PLAYERS) return;
+    if (!CVarGetInteger(kDPadJumpCVars[player_index], 0)) return;
+
+    // If any D-Pad direction is pressed, inject a C-Up (Jump) into the engine
+    if (*button_hold & (U_JPAD | D_JPAD | L_JPAD | R_JPAD)) {
+        *button_hold |= U_CBUTTON;
+        if (raw_tap & (U_JPAD | D_JPAD | L_JPAD | R_JPAD)) {
+            *button_tap |= U_CBUTTON;
+        }
+    }
+}
+
 namespace ssb64 {
 namespace enhancements {
-
-const char* TapJumpCVarName(int playerIndex) {
-    if (playerIndex < 0 || playerIndex >= PORT_ENHANCEMENT_MAX_PLAYERS) {
-        return kTapJumpCVars[0];
+    const char* TapJumpCVarName(int playerIndex) {
+        if (playerIndex < 0 || playerIndex >= PORT_ENHANCEMENT_MAX_PLAYERS) {
+            return kTapJumpCVars[0];
+        }
+        return kTapJumpCVars[playerIndex];
     }
-    return kTapJumpCVars[playerIndex];
-}
 
-const char* HitboxViewCVarName() {
-    return kHitboxViewCVar;
-}
+    const char* HitboxViewCVarName() {
+        return kHitboxViewCVar;
+    }
 
+    const char* CStickSmashCVarName(int playerIndex) {
+        if (playerIndex < 0 || playerIndex >= PORT_ENHANCEMENT_MAX_PLAYERS) {
+            return kCStickSmashCVars[0];
+        }
+        return kCStickSmashCVars[playerIndex];
+    }
+
+    const char* DPadJumpCVarName(int playerIndex) {
+        if (playerIndex < 0 || playerIndex >= PORT_ENHANCEMENT_MAX_PLAYERS) return kDPadJumpCVars[0];
+        return kDPadJumpCVars[playerIndex];
+    }
 }
 } // namespace ssb64::enhancements

--- a/port/enhancements/enhancements.h
+++ b/port/enhancements/enhancements.h
@@ -3,26 +3,31 @@
 
 #ifdef __cplusplus
 extern "C" {
-#endif
+    #endif
 
-#define PORT_ENHANCEMENT_MAX_PLAYERS 4
+    #define PORT_ENHANCEMENT_MAX_PLAYERS 4
 
-int port_enhancement_tap_jump_disabled(int player_index);
+    int port_enhancement_tap_jump_disabled(int player_index);
 
-// Hitbox-view debug overlay. Returns the dbObjectDisplayMode the caller should
-// use for the current frame. When the cvar is off this is the entity's own
-// stored display_mode; when on it overrides to a hitbox-display mode so
-// existing fighters/items/weapons flip to hitbox view immediately without a
-// match restart.
-int port_enhancement_hitbox_display_override(int current_mode);
+    // Hitbox-view debug overlay. Returns the dbObjectDisplayMode the caller should
+    // use for the current frame. When the cvar is off this is the entity's own
+    // stored display_mode; when on it overrides to a hitbox-display mode so
+    // existing fighters/items/weapons flip to hitbox view immediately without a
+    // match restart.
+    int port_enhancement_hitbox_display_override(int current_mode);
 
-#ifdef __cplusplus
+    void port_enhancement_c_stick_smash(int player_index, unsigned short* button_hold, unsigned short* button_tap, signed char* stick_x, signed char* stick_y, unsigned short raw_tap);
+    void port_enhancement_dpad_jump(int player_index, unsigned short* button_hold, unsigned short* button_tap, unsigned short raw_tap);
+
+    #ifdef __cplusplus
 }
 
 namespace ssb64 {
 namespace enhancements {
-const char* TapJumpCVarName(int playerIndex);
-const char* HitboxViewCVarName();
+    const char* TapJumpCVarName(int playerIndex);
+    const char* HitboxViewCVarName();
+    const char* CStickSmashCVarName(int playerIndex);
+    const char* DPadJumpCVarName(int playerIndex);
 }
 }
 #endif

--- a/port/gui/PortMenu.cpp
+++ b/port/gui/PortMenu.cpp
@@ -285,6 +285,7 @@ void PortMenu::AddMenuSettings() {
     path.column = SECTION_COLUMN_1;
     AddSidebarEntry("Settings", "Gameplay", 1);
 
+    /*
     AddWidget(path, "Per-Port Enhancements", WIDGET_SEPARATOR_TEXT);
     AddWidget(path, "Disable Tap Jump (P1)", WIDGET_CVAR_CHECKBOX)
         .CVar(enhancements::TapJumpCVarName(0))
@@ -304,7 +305,9 @@ void PortMenu::AddMenuSettings() {
         .CVar(enhancements::TapJumpCVarName(3))
         .RaceDisable(false)
         .Options(CheckboxOptions().Tooltip("Same as P1, applied to player 4."));
+    */
 
+    // hitbox
     AddWidget(path, "Debug", WIDGET_SEPARATOR_TEXT);
     AddWidget(path, "Hitbox View", WIDGET_CVAR_COMBOBOX)
         .CVar(enhancements::HitboxViewCVarName())
@@ -318,6 +321,59 @@ void PortMenu::AddMenuSettings() {
                               "invincible, blue=intangible).")
                      .ComboMap(kHitboxViewMap)
                      .DefaultIndex(0));
+
+        AddWidget(path, "Per-Port Enhancements", WIDGET_SEPARATOR_TEXT);
+
+        // --- Player 1 ---
+        AddWidget(path, "Player 1", WIDGET_SEPARATOR_TEXT);
+        AddWidget(path, "Disable Tap Jump (P1)", WIDGET_CVAR_CHECKBOX)
+        .CVar(enhancements::TapJumpCVarName(0))
+        .RaceDisable(false)
+        .Options(CheckboxOptions().Tooltip("Disables jumping by pushing up on the analog stick."));
+        AddWidget(path, "C-Stick Smash (P1)", WIDGET_CVAR_CHECKBOX)
+        .CVar(enhancements::CStickSmashCVarName(0))
+        .RaceDisable(false)
+        .Options(CheckboxOptions().Tooltip("Replaces C-Button inputs with instant smash attacks."));
+        AddWidget(path, "D-Pad to Jump (P1)", WIDGET_CVAR_CHECKBOX)
+        .CVar(enhancements::DPadJumpCVarName(0))
+        .RaceDisable(false)
+        .Options(CheckboxOptions().Tooltip("Translates N64 D-Pad inputs into C-Up (Jump)."));
+
+        // --- Player 2 ---
+        AddWidget(path, "Player 2", WIDGET_SEPARATOR_TEXT);
+        AddWidget(path, "Disable Tap Jump (P2)", WIDGET_CVAR_CHECKBOX)
+        .CVar(enhancements::TapJumpCVarName(1))
+        .RaceDisable(false);
+        AddWidget(path, "C-Stick Smash (P2)", WIDGET_CVAR_CHECKBOX)
+        .CVar(enhancements::CStickSmashCVarName(1))
+        .RaceDisable(false);
+        AddWidget(path, "D-Pad to Jump (P2)", WIDGET_CVAR_CHECKBOX)
+        .CVar(enhancements::DPadJumpCVarName(1))
+        .RaceDisable(false);
+
+        // --- Player 3 ---
+        AddWidget(path, "Player 3", WIDGET_SEPARATOR_TEXT);
+        AddWidget(path, "Disable Tap Jump (P3)", WIDGET_CVAR_CHECKBOX)
+        .CVar(enhancements::TapJumpCVarName(2))
+        .RaceDisable(false);
+        AddWidget(path, "C-Stick Smash (P3)", WIDGET_CVAR_CHECKBOX)
+        .CVar(enhancements::CStickSmashCVarName(2))
+        .RaceDisable(false);
+        AddWidget(path, "D-Pad to Jump (P3)", WIDGET_CVAR_CHECKBOX)
+        .CVar(enhancements::DPadJumpCVarName(2))
+        .RaceDisable(false);
+
+        // --- Player 4 ---
+        AddWidget(path, "Player 4", WIDGET_SEPARATOR_TEXT);
+        AddWidget(path, "Disable Tap Jump (P4)", WIDGET_CVAR_CHECKBOX)
+        .CVar(enhancements::TapJumpCVarName(3))
+        .RaceDisable(false);
+        AddWidget(path, "C-Stick Smash (P4)", WIDGET_CVAR_CHECKBOX)
+        .CVar(enhancements::CStickSmashCVarName(3))
+        .RaceDisable(false);
+        AddWidget(path, "D-Pad to Jump (P4)", WIDGET_CVAR_CHECKBOX)
+        .CVar(enhancements::DPadJumpCVarName(3))
+        .RaceDisable(false);
 }
 
 void PortMenu::AddMenuWindows() {

--- a/src/sys/controller.c
+++ b/src/sys/controller.c
@@ -4,6 +4,9 @@
 #include <sys/scheduler.h>
 #include <missing_libultra.h>
 #include <PR/os.h>
+#include "enhancements/enhancements.h"
+#include "sc/scmanager.h"
+#include "sc/sctypes.h"
 
 // 0x800450F0
 OSMesgQueue sSYControllerInitMesgQueue; // Queue for OS controller Init, Status, and Read
@@ -179,6 +182,15 @@ void syControllerUpdateGlobalData(void)
             gSYControllerDevices[i].button_update = sSYControllerDescs[i].unk08;
             gSYControllerDevices[i].stick_range.x = sSYControllerDescs[i].unk0E;
             gSYControllerDevices[i].stick_range.y = sSYControllerDescs[i].unk0F;
+
+            // only apply c-stick smash if we're in a game
+            if (gSCManagerBattleState != NULL && gSCManagerBattleState->players[i].fighter_gobj != NULL) {
+                // Apply C-Stick Smash
+                port_enhancement_c_stick_smash(i, &gSYControllerDevices[i].button_hold, &gSYControllerDevices[i].button_tap, &gSYControllerDevices[i].stick_range.x, &gSYControllerDevices[i].stick_range.y, sSYControllerDescs[i].unk04);
+
+                // Apply D-Pad Jump
+                port_enhancement_dpad_jump(i, &gSYControllerDevices[i].button_hold, &gSYControllerDevices[i].button_tap, sSYControllerDescs[i].unk04);
+            }
 
             sSYControllerDescs[i].unk04 = sSYControllerDescs[i].unk08 = sSYControllerDescs[i].unk0C = 0;
         }


### PR DESCRIPTION
<img width="1604" height="951" alt="Screenshot_20260502_001032" src="https://github.com/user-attachments/assets/ee999bb7-fb7f-41df-a715-f77ebb7c7a2a" />

Allows the player to set the C buttons to smash attacks, or aerial attacks if the player is in the air, as opposed to the default jump behavior. Makes it more akin to the later Smash games where the user can easily tilt the right stick to perform a smash attack.

A check is made to make sure this is only applied while the player is in the game; this ensures that the player can still adjust the character's color palette in the CSS with the C buttons without causing erratic behavior (i.e. the cursor snapping in a certain direction and hitting the A button at the same time).

If the user has tap jump disabled, this can be a problem though since they won't have any way to jump otherwise. As a compromise, I added a second toggle underneath that converts D-pad input to the C buttons. This way the player can map a button, such as X or Y on a Xbox-style gamepad, to any of the D-pad directions, and give them their jumping ability back.

Note there are some weird edge cases I've tested where, for example, the character will still jump as opposed to performing a smash attack, depending on how the stick was tilted, or the character will do a forward air attack when tilting down on the right stick immediately after jumping.

Also took the opportunity to re-organize the enhancement options in the menu a bit.