### PR TITLE
Fix Kirby copy table fixup: bound + N-Kirby coverage (Giant DK crash)

### DIFF
--- a/src/ft/ftmanager.c
+++ b/src/ft/ftmanager.c
@@ -663,27 +663,38 @@ void ftManagerInitFighter(GObj *fighter_gobj, FTDesc *desc)
         }
         else fp->passive_vars.kirby.is_ignore_losecopy = TRUE;
 
-        if (fp->fkind == nFTKindKirby)
         {
             FTKirbyCopy *copy = lbRelocGetFileData(FTKirbyCopy*, gFTDataKirbyMainMotion, llKirbyMainMotionSpecialNFTKirbyCopy);
 #ifdef PORT
             /* PORT: FTKirbyCopy's first u32 word is [u16 copy_id][s16 copy_modelpart_id]
-             * — adjacent u16s in one word.  Pass1's blanket BSWAP32 position-swaps the
-             * two halves, so without this fixup the copy_id/copy_modelpart_id read as
-             * each other's values.  Array is indexed by any fkind (0..nFTKindNEnd) via
-             * the eat/inhale path `copy[victim_fp->fkind]`, so every entry must be
-             * fixed up — not just copy[8] (Kirby).  26 entries span all playable
-             * (0..11), Boss (12), MMario (13), and N-series (14..25).
-             * Idempotent via sStructU16Fixups (keyed on per-entry pointer). */
+             * — adjacent u16s in one word.  Pass1's blanket BSWAP32 position-swaps
+             * the two halves, so without this fixup copy_id/copy_modelpart_id read
+             * as each other's values.
+             *
+             * The consumer in ftkirbyspecialn.c (the eat/inhale path) indexes the
+             * array by raw `victim_fp->fkind` — which on the Giant DK 1P stage is
+             * `nFTKindGDonkey`, beyond `nFTKindNEnd`.  The fixup domain MUST match
+             * the consumer's domain or specific stages corrupt copy_id and dispatch
+             * Kirby into the wrong character's special-N (originally surfaced as a
+             * NULL deref in wpManagerMakeWeapon when GiantDK landed on Mario's
+             * fireball spawn).  Iterate the full FTKind value range so this stays
+             * correct if the enum grows.  Run for both Kirby and N-Kirby spawns:
+             * polygon-Kirby on 1P stage 12 uses real Kirby's AI attack table and
+             * fires neutral-B at any nearby polygon, so its eat path also reads
+             * copy[fkind] — must be fixed up even when the player isn't Kirby.
+             * Idempotent via sStructU16Fixups. */
             {
                 s32 i;
-                for (i = 0; i <= nFTKindNEnd; i++)
+                for (i = 0; i < nFTKindEnumCount; i++)
                 {
                     portFixupStructU16(&copy[i], 0, 1);
                 }
             }
 #endif
-            ftParamSetModelPartDefaultID(fighter_gobj, FTKIRBY_COPY_MODELPARTS_JOINT, copy[fp->passive_vars.kirby.copy_id].copy_modelpart_id);
+            if (fp->fkind == nFTKindKirby)
+            {
+                ftParamSetModelPartDefaultID(fighter_gobj, FTKIRBY_COPY_MODELPARTS_JOINT, copy[fp->passive_vars.kirby.copy_id].copy_modelpart_id);
+            }
         }
         break;
 


### PR DESCRIPTION
## Summary

- Extend `FTKirbyCopy` u16 fixup loop to cover the full `FTKind` enum (was off-by-one at `nFTKindGDonkey`, breaking Kirby vs Giant DK 1P stage)
- Lift the fixup out of the real-Kirby-only gate so polygon-Kirby spawns also trigger it (latent crash on 1P stage 12 for non-Kirby players)

## Root cause (PORT only)

`FTKirbyCopy`'s first u32 word is `[u16 copy_id][s16 copy_modelpart_id]`. Pass1's blanket BSWAP32 on LE position-swaps those halves; `portFixupStructU16` rotates each entry's first word back to N64 layout. The fixup had two domain mismatches with its consumer:

**1. Loop bound was off-by-one at GDonkey.**

The eat path `ftkirbyspecialn.c:193` indexes `copy[victim_fp->fkind].copy_id` for any fighter Kirby can swallow — including `nFTKindGDonkey` (=26) when Kirby is on 1P stage 7. The loop ran `i <= nFTKindNEnd` (=25), so `copy[26]` stayed unrotated. Reading its `copy_id` returned the position-swapped `copy_modelpart_id` value (a small joint index that landed on `nFTKindMario`), and dispatch went to `ftKirbyCopyMarioSpecialNProcAccessory` → spawned a Mario fireball → NULL deref at offset 0x28 inside `wpManagerMakeWeapon` (Mario's fighter file isn't loaded on this stage).

**Backtrace from the original crash:**
```
SSB64: !!!! CRASH SIGSEGV fault_addr=0x28
0  wpManagerMakeWeapon + 1288
2  wpMarioFireballMakeWeapon + 104
3  ftKirbyCopyMarioSpecialNProcAccessory + 192
4  ftMainProcPhysicsMap + 1436
```

Loop now runs `i < nFTKindEnumCount` so it auto-extends with the enum.

**2. Fixup was gated on `fp->fkind == nFTKindKirby`, so polygon-Kirby never triggered it.**

`dFTComputerAttackList[nFTKindNKirby] = dFTComputerAttacksKirby` (`ftcomputer.c:2740`) — polygon-Kirby uses real Kirby's full AI attack table, including its `SpecialN` entry (range 45–470 horizontal, 80–370 vertical). On 1P stage 12 (Fighting Polygon Team) with any non-Kirby player, no real Kirby has spawned this session, so the table is unfixed. Polygon-Kirby's first inhale of any nearby polygon would have crashed in the same class — `copy[N_fkind]` reads garbage, dispatches to a real character's SpecialN whose fighter file isn't loaded.

Lifted the fixup out of the inner `if (fp->fkind == nFTKindKirby)` gate. The model-part call (real Kirby's swallow-mouth skeleton node) stays gated.

## Why this is the root-cause fix, not a hotfix

- Loop bound now matches the consumer's domain by construction: anything `victim_fp->fkind` can be is in `[0, nFTKindEnumCount)`. Future enum additions auto-extend.
- Producer's domain (who triggers fixup) now matches consumer's domain (who reads the table) — both Kirbys.
- Audited every other `FTKirbyCopy` field access: only `copy_id` and `copy_modelpart_id` (the swapped pair) need rotation; `effect_scale` (f32) and `star_damage` (s32, offset 0x8) are full u32 words already correct after pass1.
- N64/IDO is BE: `copy[N].copy_id` reads the original ROM bytes correctly with no transformation. The fixup is a port-only concern; this PR doesn't touch decomp game logic.

## Test plan

- [x] Boot Kirby vs Giant DK 1P stage, swallow DK, use copied special-N — no crash, correct ability (Giant Punch)
- [ ] 1P stage 12 (Fighting Polygon Team) with non-Kirby player — verify polygon-Kirby's neutral-B inhale resolves to a polygon-character's special-N without crashing
- [ ] Regression: real Kirby vs all standard 1P opponents (verify nothing else changed about copy_id resolution)

🤖 Generated with [Claude Code](https://claude.com/claude-code)