### PR TITLE
Fix sound test menu reloc flood + SSB64_START_SCENE crash on exit

### DIFF
--- a/src/mn/mndata/mnsoundtest.c
+++ b/src/mn/mndata/mnsoundtest.c
@@ -11,6 +11,34 @@ extern void func_800266A0_272A0(void);
 
 extern void* func_800269C0_275C0(u16);
 
+#ifdef PORT
+extern void portFixupSprite(void *sprite);
+extern void portFixupBitmapArray(void *bitmaps, unsigned int count);
+extern void portFixupSpriteBitmapData(void *sprite, void *bitmaps);
+
+/* Mirror of ifCommonPortFixupSpriteFull. Sound test value-copies digit
+ * Sprites out of llIFCommonPlayerDamageFileID at mnsoundtest.c:1499
+ * (sobj->sprite = *lbRelocGetFileData(...)), bypassing the fixup that
+ * lbCommonMakeSObjForGObj normally applies. Digits 1-9 thus walk the
+ * renderer through unfixed Sprite/Bitmap headers, producing the
+ * RelocPointerTable "invalid/stale token" flood from
+ * lbCommonDrawSObjBitmap when the menu opens. Pre-fixing every digit at
+ * load time keeps the value-copy path correct. */
+static void mnSoundTestPortFixupSpriteFull(Sprite *sprite)
+{
+    if (sprite == NULL) return;
+    portFixupSprite(sprite);
+    {
+        Bitmap *bitmaps = (Bitmap*)PORT_RESOLVE(sprite->bitmap);
+        if (bitmaps != NULL)
+        {
+            portFixupBitmapArray(bitmaps, sprite->nbitmaps);
+            portFixupSpriteBitmapData(sprite, bitmaps);
+        }
+    }
+}
+#endif
+
 // // // // // // // // // // // //
 //                               //
 //             MACROS            //
@@ -1025,6 +1053,25 @@ void mnSoundTestSetupFiles(void)
 
     lbRelocInitSetup(&rl_setup);
     lbRelocLoadFilesListed(dMNSoundTestFileIDs, sMNSoundTestFiles);
+
+#ifdef PORT
+    /* Pre-fixup the 10 digit Sprites in llIFCommonPlayerDamageFileID
+     * (sMNSoundTestFiles[1]). mnSoundTestUpdateNumberSprites copies
+     * these by value into sobj->sprite (line 1499) without going
+     * through lbCommonMakeSObjForGObj, so without this loop only digit
+     * 0 (used by mnSoundTestMakeNumberSObj) would have its byte order
+     * corrected — digits 1-9 would render through garbled Bitmap
+     * headers and flood the RelocPointerTable with stale tokens. */
+    {
+        s32 i;
+        for (i = 0; i < ARRAY_COUNT(dMNSoundTestDigitSpriteOffsets); i++)
+        {
+            mnSoundTestPortFixupSpriteFull(
+                lbRelocGetFileData(Sprite*, sMNSoundTestFiles[1],
+                                   dMNSoundTestDigitSpriteOffsets[i]));
+        }
+    }
+#endif
 }
 
 // 0x8013234C

--- a/src/sc/scmanager.c
+++ b/src/sc/scmanager.c
@@ -899,7 +899,18 @@ void scManagerRunLoop(sb32 arg)
 			int n = atoi(env);
 			gSCManagerSceneData.scene_curr = n;
 			gSCManagerSceneData.scene_prev = n;
-			port_log("SSB64: SSB64_START_SCENE override → scene=%d\n", n);
+			/* The override jumps the player into a scene that they may
+			 * not have unlocked yet (e.g. nSCKindSoundTest requires
+			 * LBBACKUP_UNLOCK_MASK_SOUNDTEST). Several menus assume
+			 * scene_prev only ever names a reachable scene, and gate
+			 * GObj creation on the matching unlock bit. Visiting Sound
+			 * Test on a fresh save and pressing B otherwise drops back
+			 * into the Data menu with sMNDataOption=SoundTest but
+			 * sMNDataOptionSoundTestGObj=NULL → SIGSEGV. Granting all
+			 * unlocks alongside the scene override keeps backup-mask
+			 * state consistent with where the user told us to start. */
+			gSCManagerBackupData.unlock_mask |= LBBACKUP_UNLOCK_MASK_ALL;
+			port_log("SSB64: SSB64_START_SCENE override → scene=%d (unlock_mask |= ALL)\n", n);
 		}
 		const char *stage_env = getenv("SSB64_SPGAME_STAGE");
 		if (stage_env != NULL)


### PR DESCRIPTION
## Summary

Two related fixes for the Sound Test menu under the LP64 port. Independently confirmed via `SSB64_START_SCENE=59`:

- **`src/mn/mndata/mnsoundtest.c`** — pre-fixup the 10 digit Sprites in `llIFCommonPlayerDamageFileID` at file-load time. `mnSoundTestUpdateNumberSprites` does `sobj->sprite = *lbRelocGetFileData(Sprite*, ...)`, which value-copies the digit Sprite from file data without going through `lbCommonMakeSObjForGObj`. On LP64 the file has only had pass1 BSWAP32 applied, so `nbitmaps` reads as the original `ndisplist` (36) and the renderer walks 36 garbage Bitmap structs per draw. Symptom: selected-track digits never render and `~35,000` RelocPointerTable invalid/stale-token errors per session. Mirrors the existing `ifCommonPlayerDamageSetDigitAttr` pattern (same file, same digit sprites, same trap, already fixed there).

- **`src/sc/scmanager.c`** — when `SSB64_START_SCENE` honours an override, OR `LBBACKUP_UNLOCK_MASK_ALL` into `gSCManagerBackupData.unlock_mask`. The decomp assumes `scene_prev` only ever names a scene the player was allowed to reach; that invariant gates `mnDataMakeSoundTest()` (and likely other unlock-conditional GObj setups). The override violates it on a fresh save: jumping into Sound Test and pressing B back to Data sets `sMNDataOption=SoundTest` while `sMNDataOptionSoundTestGObj=NULL`, crashing in `mnDataSetOptionSpriteColors` at offset 0xC8. Restoring the invariant at the override site (rather than clamping at every consumer) keeps mndata.c and any future unlock-conditional menus correct without per-site defensive guards.

## Verification

- `SSB64_START_SCENE=59` + navigate music/sounds/voices: digits render correctly across all 10 positions, RelocPointerTable error count went from `35,003` → `0`, NULL bitmap->buf log went from `20` → `0`.
- Same path + B-back into Data menu: lands cleanly on Sound Test option highlighted, no SIGSEGV.

## Test plan

- [ ] Load a save with Sound Test unlocked normally, navigate Title → Data → Sound Test, confirm digits render and B-back into Data still works (no regression on the unlock_mask path).
- [ ] `SSB64_START_SCENE=59` on fresh save: enter, scrub all three options, B-back to Data, exit to Title — should be clean.
- [ ] Fresh save without override: confirm Sound Test is still gated behind its unlock condition (the override-site code only runs when `getenv("SSB64_START_SCENE") != NULL`, so normal play is unaffected).

🤖 Generated with [Claude Code](https://claude.com/claude-code)