### PR TITLE
Apply tap-jump-disabled to Kirby/Jigglypuff multi-jumps

### DIFF
--- a/src/ft/ftcommon/ftcommonjumpaerial.c
+++ b/src/ft/ftcommon/ftcommonjumpaerial.c
@@ -1,5 +1,9 @@
 #include <ft/fighter.h>
 
+#ifdef PORT
+#include <enhancements/enhancements.h>
+#endif
+
 // // // // // // // // // // // //
 //                               //
 //       INITIALIZED DATA        //
@@ -263,7 +267,13 @@ sb32 ftCommonJumpAerialMultiCheckJumpButtonHold(FTStruct *fp)
 // 0x80140150
 s32 ftCommonJumpAerialMultiGetJumpInputType(FTStruct *fp)
 {
-    if (fp->input.pl.stick_range.y >= FTCOMMON_JUMPAERIAL_STICK_RANGE_MIN)
+#ifdef PORT
+    sb32 tap_jump_disabled = port_enhancement_tap_jump_disabled(fp->player);
+#else
+    sb32 tap_jump_disabled = FALSE;
+#endif
+
+    if (!tap_jump_disabled && (fp->input.pl.stick_range.y >= FTCOMMON_JUMPAERIAL_STICK_RANGE_MIN))
     {
         return FTCOMMON_JUMPAERIAL_INPUT_TYPE_STICK;
     }


### PR DESCRIPTION
## Summary
- Kirby and Jigglypuff's 2nd–5th aerial jumps ignored the **Disable Tap Jump** cvar — an upward stick still triggered the jump even with the enhancement on.
- Ground jumps and every fighter's *first* aerial jump go through `ftCommonKneeBendGetInputTypeCommon`, which already honors `port_enhancement_tap_jump_disabled`. Multi-jumps (jumps 2–5) for Kirby/Puff use a separate path, `ftCommonJumpAerialMultiGetJumpInputType` at `src/ft/ftcommon/ftcommonjumpaerial.c:264`, that read the stick directly with no guard.
- This adds the same `#ifdef PORT` tap-jump check to the multi-jump function. The C-button path is unchanged so deliberate jump-button presses still work.

## Test plan
- [ ] Local Debug build succeeds (verified — `BattleShip` links clean).
- [ ] In-game: P1 Kirby with `Disable Tap Jump (P1)` enabled — upward stick during 2nd–5th aerial jumps does **not** consume a jump; jump button still does.
- [ ] In-game: same with P1 Jigglypuff.
- [ ] In-game: tap jump still works for both characters when the cvar is **off**.
- [ ] In-game: non-Kirby/Puff fighters unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)