### PR TITLE
Drop per-frame ftAnimParse port_log spam

### DIFF
--- a/src/ft/ftanim.c
+++ b/src/ft/ftanim.c
@@ -331,22 +331,10 @@ void ftAnimParseDObjFigatree(DObj *root_dobj)
                 break;
 
             case nGCAnimEvent16Block:
-#ifdef PORT
-                {
-                    u16 *raw16 = (u16*)root_dobj->anim_joint.event16;
-                    u32 raw32 = *(u32*)root_dobj->anim_joint.event16;
-                    port_log("SSB64: ftAnimParse BLOCK dobj=%p parent=%p raw16=[0x%04x 0x%04x 0x%04x 0x%04x] raw32=0x%08x pre_wait=%f pre_frame=%f\n",
-                        root_dobj, root_dobj->parent_gobj, raw16[0], raw16[1], raw16[2], raw16[3], raw32, root_dobj->anim_wait, root_dobj->anim_frame);
-                }
-#endif
                 if (AObjAnimAdvance(root_dobj->anim_joint.event16)->command.toggle)
                 {
                     root_dobj->anim_wait += AObjAnimAdvance(root_dobj->anim_joint.event16)->u;
                 }
-#ifdef PORT
-                port_log("SSB64: ftAnimParse BLOCK post_wait=%f event16_now=%p\n",
-                    root_dobj->anim_wait, root_dobj->anim_joint.event16);
-#endif
                 break;
 
             case nGCAnimEvent16SetValAfterBlock:
@@ -481,12 +469,6 @@ void ftAnimParseDObjFigatree(DObj *root_dobj)
                 break;
 
             case nGCAnimEvent32End:
-#ifdef PORT
-                port_log("SSB64: ftAnimParse END dobj=%p parent_gobj=%p prev_anim_wait=%f prev_anim_frame=%f is_anim_root=%d func_anim=%p\n",
-                    root_dobj, root_dobj->parent_gobj, root_dobj->anim_wait, root_dobj->anim_frame,
-                    (int)root_dobj->is_anim_root,
-                    root_dobj->parent_gobj ? (void*)root_dobj->parent_gobj->func_anim : NULL);
-#endif
                 current_aobj = root_dobj->aobj;
 
                 while (current_aobj != NULL)


### PR DESCRIPTION
## Summary

- `ftAnimParseDObjFigatree`'s `nGCAnimEvent16Block` and `nGCAnimEvent32End` arms emitted `port_log` calls every time the anim cursor hit a BLOCK/END opcode — i.e. constantly, per DObj, per frame.
- `port_log` `fflush()`es after every line (crash-safe by design), so each call costs a synchronous disk write. With four fighters idle-dancing on the VS character-select screen this is a wall of writes per frame.
- These prints were debug instrumentation left over from the figatree halfswap and spline-interp investigations (see `docs/bugs/aobjevent32_halfswap_*`, `docs/bugs/spline_interp_block_halfswap_*`). Both root causes are resolved; the watchdog log at `ftanim.c:149` and the 32-line cap on the TraI command trace cover any future regressions in this area.
- Only the log code is removed. The `AObjAnimAdvance` / `anim_wait` update for the Block opcode is preserved verbatim.

## Context

Surfaced while investigating issue #78 (CSS framedrops with 4 chars selected). The 4-char framedrop turned out to be a Debug-build artifact — Release was smooth. But the per-frame log spam is real waste regardless of build type and worth removing on its own merits.

## Test plan

- [x] Worktree builds clean (Debug + Release)
- [x] Boot to title, enter VS CSS, observe `ssb64.log` has zero `ftAnimParse` lines (verified — runtime log was 70 lines of startup-only after this change vs prior runs that flooded with per-frame BLOCK traces)
- [ ] Smoke test: fighter animations still play correctly in CSS, attract demo, and a quick VS battle (animations rely on the preserved AObjAnimAdvance call inside the Block arm)

🤖 Generated with [Claude Code](https://claude.com/claude-code)