### PR TITLE
Fix #78: gate RCP cost-model freezes by scene

### DIFF
--- a/port/gameloop.cpp
+++ b/port/gameloop.cpp
@@ -252,6 +252,21 @@ extern "C" int port_get_last_dl_defer_n(void)
 	}
 	if (sForceN >= 1) return sForceN;
 
+	/* Scene-level allowlist gate. The cost model exists to recreate the
+	 * authored climax-freeze frames in cutscenes / opening sequences /
+	 * fighter intros (where original-game scene authors timed dialogue,
+	 * camera, and audio around the natural N64 RDP overrun). It has no
+	 * business firing in interactive menus or CSS — there are no authored
+	 * freezes there to preserve, and the cost+rect heuristic mis-fires on
+	 * UI-fillrate-heavy DLs (4-fighter VS CSS panels cluster at cost ≈420k,
+	 * rect_px ≈236k, which trips both gates every frame and halves the
+	 * game-tick rate). Issue #78. */
+	extern unsigned char port_diag_get_scene_curr(void);
+	extern int port_scene_wants_freeze_simulation(unsigned char scene_id);
+	if (!port_scene_wants_freeze_simulation(port_diag_get_scene_curr())) {
+		return 1;
+	}
+
 	int cost = sLastDLTris * 75
 	         + sLastDLRectPx
 	         + sLastDLLoadBytes;

--- a/port/stubs/port_diag_stubs.c
+++ b/port/stubs/port_diag_stubs.c
@@ -91,3 +91,50 @@ const char *port_diag_get_scene_name(u8 id)
 	default:                      return "?";
 	}
 }
+
+/* Whether the current scene has authored climax-freeze frames whose timing
+ * is preserved by the RCP cost-model in port/gameloop.cpp.
+ *
+ * The cost model treats DLs that exceed budget+rect_gate as "authored freezes"
+ * and stretches them across multiple VIs to mimic real-N64 RDP overrun. That
+ * fidelity is only needed in scenes that play the pre-rendered character
+ * intro sequences whose climaxes (Yoshi tongue, Samus grapple, DK smash, etc.)
+ * the game authors timed around the natural overrun:
+ *   - AutoDemo (attract loop cycles through them)
+ *   - the various Opening scenes (first-boot intros, mvOpening*)
+ *   - Ending cutscene
+ *
+ * Everywhere else (CSS, menus, normal battle, 1P game, bonus stages, training,
+ * stage clear, etc.) the cost+rect heuristic just mis-fires on UI-fillrate-
+ * heavy DLs — the 4-fighter VS CSS panels cluster at cost ≈420k, rect_px ≈236k,
+ * which trips both gates every frame and halves the game-tick rate. Issue #78.
+ */
+sb32 port_scene_wants_freeze_simulation(u8 scene_id)
+{
+	switch (scene_id) {
+	case nSCKindOpeningRoom:
+	case nSCKindOpeningPortraits:
+	case nSCKindOpeningMario:
+	case nSCKindOpeningDonkey:
+	case nSCKindOpeningSamus:
+	case nSCKindOpeningFox:
+	case nSCKindOpeningLink:
+	case nSCKindOpeningYoshi:
+	case nSCKindOpeningPikachu:
+	case nSCKindOpeningKirby:
+	case nSCKindOpeningRun:
+	case nSCKindOpeningYoster:
+	case nSCKindOpeningCliff:
+	case nSCKindOpeningStandoff:
+	case nSCKindOpeningYamabuki:
+	case nSCKindOpeningClash:
+	case nSCKindOpeningSector:
+	case nSCKindOpeningJungle:
+	case nSCKindOpeningNewcomers:
+	case nSCKindEnding:
+	case nSCKindAutoDemo:
+		return TRUE;
+	default:
+		return FALSE;
+	}
+}

--- a/src/sys/objdisplay.c
+++ b/src/sys/objdisplay.c
@@ -180,10 +180,25 @@ static void gcRenderDiagDescribePointer(const void *ptr, u32 *file_id, uintptr_t
     }
 }
 
+/* SSB64_RENDER_DIAG is a one-shot diagnostic, never toggled mid-run. Cache the
+ * enabled state so the per-MObj fast path doesn't take the macOS getenv
+ * unfair-lock + linear __environ walk on every call. With 4 fighters in a busy
+ * scene that's hundreds of locked env walks per frame for an opt-out check
+ * that nearly always returns "off". */
+static bool gcRenderDiagEnabled(void)
+{
+    static int sCached = -1;
+    if (sCached == -1)
+    {
+        const char *enabled = getenv("SSB64_RENDER_DIAG");
+        sCached = (enabled != NULL && enabled[0] != '\0' && enabled[0] != '0') ? 1 : 0;
+    }
+    return sCached != 0;
+}
+
 static void gcRenderDiagLogMObj(DObj *dobj, MObj *mobj, u16 flags, void *current_sprite, u32 current_sprite_token,
                                 void *next_sprite, u32 next_sprite_token, void *palette_data, u32 palette_token)
 {
-    const char *enabled = getenv("SSB64_RENDER_DIAG");
     bool matches;
     u32 cur_file;
     u32 next_file;
@@ -198,7 +213,7 @@ static void gcRenderDiagLogMObj(DObj *dobj, MObj *mobj, u16 flags, void *current
     const char *pal_path;
     const char *dl_path;
 
-    if ((enabled == NULL) || (enabled[0] == '\0') || (enabled[0] == '0') || (sGCMObjRenderDiagCount >= gcRenderDiagLimit()))
+    if (!gcRenderDiagEnabled() || (sGCMObjRenderDiagCount >= gcRenderDiagLimit()))
     {
         return;
     }


### PR DESCRIPTION
Closes #78.

## Summary

The synthetic RCP-overrun cost model in `port_get_last_dl_defer_n()` was firing on every VS character-select frame when all four player slots were filled. Each CSS DL clusters at cost ≈420k with rect_px ≈236k (panels + 4 portraits + 4 name plates + heavy texture loads), tripping both the cycle budget and the fillrate gate. The model classifies it as an authored climax-freeze and returns N=3, deferring SP/DP completion 3 VIs. The game thread then blocks on slot contention every other VI, `dl_submits` halve from ~60/s to ~30/s, and the user perceives ~24 fps stutter the moment the 4th character is selected.

## Diagnosis

Telemetry over a 1-second PortPushFrame window:

| State | vis/s | dl_submits/s | idle_vis/s | resume_ms_avg |
|---|---|---|---|---|
| 3 chars selected | 61 | 61 | 0 | 16.4 |
| 4 chars selected (broken) | 60 | 24 | 36 | 8.0 |
| 4 chars + `SSB64_RCP_FORCE_N=1` | 61 | 61 | 0 | 16.5 |

Per-DL trace at the bug: `cost=420337, tris=1232, rect_px=236289, load=91648 → N=3 (freeze)`.

Critically, `resume_ms_avg ≈ 8ms` at 4 chars proved the cooperative-scheduler pass is **not** CPU-saturated — we have plenty of budget. The 30 fps was an explicit halving via the cost model, not natural lag.

## Fix

The cost model exists to recreate the authored climax freezes that the original game's scene authors timed around natural N64 RDP overrun — Yoshi's tongue, Samus's grapple, DK's smash, the desk→arena explosion, etc. Those climaxes only play in pre-rendered intro / cutscene scenes (AutoDemo, the Opening* family, Ending). They never play in interactive menus, CSS, normal battle, or 1P game.

This PR adds `port_scene_wants_freeze_simulation()` next to the existing scene accessors in `port/stubs/port_diag_stubs.c`. `port_get_last_dl_defer_n` short-circuits to N=1 when the scene isn't on the allowlist. No env var to opt back in — if a scene later turns out to need freezes, add it to the switch. `SSB64_RCP_FORCE_N` still works to pin N for testing, and `SSB64_RCP_CYCLE_BUDGET` / `RECT_GATE` still tune the model for the scenes where it does run.

## Ride-along

Second commit caches `SSB64_RENDER_DIAG` getenv in `gcRenderDiagLogMObj`. That function is called per-MObj-per-frame, and on macOS getenv takes a process-wide unfair lock + linear `__environ` walk every call. This was visible in the sample profile and is unambiguously correct regardless of whether it moves the needle on any specific scene — turned out not to be the actual cause of the 4-fighter framedrop but the per-frame waste is real.

## Test plan

- [x] 4-char VS CSS — smooth 60 fps after fix (was 24 fps)
- [x] 3-char VS CSS — still smooth 60 fps (no regression)
- [x] AutoDemo — fighter intro climax freezes (Yoshi tongue, Samus grapple) still play with their authored timing
- [x] Boot sequence Opening scenes — still freeze on climax frames
- [ ] VS battle gameplay — should be smooth (cost model now skipped here, was already mostly skipped by the rect_gate so no perceptible difference expected)
- [ ] 1P game gameplay — same
- [ ] Stage clear screen — photo wipe transition still looks correct

🤖 Generated with [Claude Code](https://claude.com/claude-code)