### PR TITLE
Add per-player NRage-style analog stick remap + Controls sidebar

### DIFF
--- a/port/enhancements/enhancements.cpp
+++ b/port/enhancements/enhancements.cpp
@@ -1,6 +1,14 @@
 #include "enhancements.h"
 
 #include <libultraship/bridge/consolevariablebridge.h>
+#include <ship/Context.h>
+#include <ship/controller/controldeck/ControlDeck.h>
+#include <ship/controller/controldevice/controller/Controller.h>
+#include <ship/controller/controldevice/controller/ControllerStick.h>
+#include <ship/controller/controldevice/controller/mapping/ControllerAxisDirectionMapping.h>
+
+#include <algorithm>
+#include <cmath>
 
 namespace {
 
@@ -27,6 +35,34 @@ constexpr const char* kDPadJumpCVars[PORT_ENHANCEMENT_MAX_PLAYERS] = {
     "gEnhancements.DPadJump.P3",
     "gEnhancements.DPadJump.P4",
 };
+
+// Per-player NRage-style analog-stick remap. When the enable cvar for a player
+// is on, src/sys/controller.c discards the libultraship Process()'d int8_t
+// stick output and recomputes the value from the raw per-direction axis
+// magnitudes via the per-axis formula in
+// usbh_xpad.c (Ownasaurus/USBtoN64v2). Disabled by default; the LUS pipeline
+// (circular deadzone + octagonal gate + notch snap) runs unchanged when off.
+constexpr const char* kAnalogRemapEnableCVars[PORT_ENHANCEMENT_MAX_PLAYERS] = {
+    "gEnhancements.AnalogRemap.P1",
+    "gEnhancements.AnalogRemap.P2",
+    "gEnhancements.AnalogRemap.P3",
+    "gEnhancements.AnalogRemap.P4",
+};
+constexpr const char* kAnalogRemapDeadzoneCVars[PORT_ENHANCEMENT_MAX_PLAYERS] = {
+    "gEnhancements.AnalogRemap.P1.Deadzone",
+    "gEnhancements.AnalogRemap.P2.Deadzone",
+    "gEnhancements.AnalogRemap.P3.Deadzone",
+    "gEnhancements.AnalogRemap.P4.Deadzone",
+};
+constexpr const char* kAnalogRemapRangeCVars[PORT_ENHANCEMENT_MAX_PLAYERS] = {
+    "gEnhancements.AnalogRemap.P1.Range",
+    "gEnhancements.AnalogRemap.P2.Range",
+    "gEnhancements.AnalogRemap.P3.Range",
+    "gEnhancements.AnalogRemap.P4.Range",
+};
+
+constexpr float kAnalogRemapDeadzoneDefault = 0.10f;
+constexpr float kAnalogRemapRangeDefault    = 1.00f;
 
 // N64 button bitmasks. Duplicated here so the C++ layer doesn't have to pull
 // in PR/os.h. Kept narrow (only what these enhancements need); if more
@@ -106,6 +142,72 @@ extern "C" void port_enhancement_c_stick_smash(int player_index, unsigned short*
     }
 }
 
+// NRage-style per-axis stick remap. See header comment for the design.
+//
+// Reads the raw per-direction normalized magnitudes from libultraship
+// (0..MAX_AXIS_RANGE per direction) and reconstructs a signed per-axis value,
+// then applies the verbatim usbh_xpad.c formula independently to X and Y:
+//   - linear deadzone subtraction with rescale gain
+//   - asymmetric negative branch (`-(in+1)`), faithful to the source
+//   - linear range scale capped at 127
+// No octagonal gate, no radial deadzone, no notch snap.
+//
+// When the enable cvar is off, this is a no-op so libultraship's Process()
+// output flows through to the game unchanged.
+extern "C" void port_enhancement_analog_remap(int player_index, signed char* stick_x, signed char* stick_y) {
+    if (player_index < 0 || player_index >= PORT_ENHANCEMENT_MAX_PLAYERS) return;
+    if (!CVarGetInteger(kAnalogRemapEnableCVars[player_index], 0)) return;
+
+    auto ctx = Ship::Context::GetInstance();
+    if (!ctx) return;
+    auto deck = ctx->GetControlDeck();
+    if (!deck) return;
+    auto controller = deck->GetControllerByPort(static_cast<uint8_t>(player_index));
+    if (!controller) return;
+    auto stick = controller->GetLeftStick();
+    if (!stick) return;
+
+    const float right = stick->GetAxisDirectionValue(Ship::RIGHT);
+    const float left  = stick->GetAxisDirectionValue(Ship::LEFT);
+    const float up    = stick->GetAxisDirectionValue(Ship::UP);
+    const float down  = stick->GetAxisDirectionValue(Ship::DOWN);
+
+    // Per-axis signed input in [-RAW_MAX, +RAW_MAX].
+    const float in_x = right - left;
+    const float in_y = up - down;
+
+    // RAW_MAX matches libultraship's MAX_AXIS_RANGE (85.0f) — the per-direction
+    // normalized cap GetAxisDirectionValue() can return.
+    constexpr float RAW_MAX = 85.0f;
+    const float dz_pct =
+        std::clamp(CVarGetFloat(kAnalogRemapDeadzoneCVars[player_index], kAnalogRemapDeadzoneDefault), 0.0f, 0.99f);
+    const float rng_pct =
+        std::clamp(CVarGetFloat(kAnalogRemapRangeCVars[player_index], kAnalogRemapRangeDefault), 0.50f, 1.50f);
+
+    const float dz_val      = dz_pct * RAW_MAX;
+    const float dz_relation = (RAW_MAX > dz_val) ? RAW_MAX / (RAW_MAX - dz_val) : 1.0f;
+    const float n64_max     = 127.0f * rng_pct;
+    const float scale       = n64_max / RAW_MAX;
+
+    auto remap_axis = [&](float in) -> signed char {
+        if (in >= dz_val) {
+            float out = (in - dz_val) * dz_relation * scale;
+            if (out > 127.0f) out = 127.0f;
+            return static_cast<signed char>(out);
+        } else if (in <= -dz_val) {
+            // Verbatim source asymmetry: temp = -(in+1) before deadzone math.
+            float temp = -(in + 1.0f);
+            float out  = (temp - dz_val) * dz_relation * scale;
+            if (out > 127.0f) out = 127.0f;
+            return static_cast<signed char>(-out);
+        }
+        return 0;
+    };
+
+    *stick_x = remap_axis(in_x);
+    *stick_y = remap_axis(in_y);
+}
+
 extern "C" void port_enhancement_dpad_jump(int player_index, unsigned short* button_hold, unsigned short* button_tap, unsigned short tap_pre_remap) {
     if (player_index < 0 || player_index >= PORT_ENHANCEMENT_MAX_PLAYERS) return;
     if (!CVarGetInteger(kDPadJumpCVars[player_index], 0)) return;
@@ -149,6 +251,27 @@ const char* DPadJumpCVarName(int playerIndex) {
         return kDPadJumpCVars[0];
     }
     return kDPadJumpCVars[playerIndex];
+}
+
+const char* AnalogRemapCVarName(int playerIndex) {
+    if (playerIndex < 0 || playerIndex >= PORT_ENHANCEMENT_MAX_PLAYERS) {
+        return kAnalogRemapEnableCVars[0];
+    }
+    return kAnalogRemapEnableCVars[playerIndex];
+}
+
+const char* AnalogRemapDeadzoneCVarName(int playerIndex) {
+    if (playerIndex < 0 || playerIndex >= PORT_ENHANCEMENT_MAX_PLAYERS) {
+        return kAnalogRemapDeadzoneCVars[0];
+    }
+    return kAnalogRemapDeadzoneCVars[playerIndex];
+}
+
+const char* AnalogRemapRangeCVarName(int playerIndex) {
+    if (playerIndex < 0 || playerIndex >= PORT_ENHANCEMENT_MAX_PLAYERS) {
+        return kAnalogRemapRangeCVars[0];
+    }
+    return kAnalogRemapRangeCVars[playerIndex];
 }
 
 }

--- a/port/enhancements/enhancements.h
+++ b/port/enhancements/enhancements.h
@@ -39,6 +39,15 @@ void port_enhancement_c_stick_smash(int player_index, unsigned short* button_hol
 // `tap_pre_remap` has the same meaning as above.
 void port_enhancement_dpad_jump(int player_index, unsigned short* button_hold, unsigned short* button_tap, unsigned short tap_pre_remap);
 
+// Per-player NRage-style analog-stick remap. When the per-player toggle is on,
+// rewrites *stick_x/*stick_y from libultraship's raw per-direction axis values
+// using the verbatim per-axis deadzone+range formula from
+// Ownasaurus/USBtoN64v2 (usbh_xpad.c), bypassing libultraship's circular
+// deadzone, octagonal-gate clamp, and notch snap. When the toggle is off this
+// is a no-op and libultraship's stock pipeline output flows through unchanged
+// — both schemes coexist, the toggle picks which runs.
+void port_enhancement_analog_remap(int player_index, signed char* stick_x, signed char* stick_y);
+
 #ifdef __cplusplus
 }
 
@@ -49,6 +58,9 @@ const char* HitboxViewCVarName();
 const char* StageClearFrozenWallpaperCVarName();
 const char* CStickSmashCVarName(int playerIndex);
 const char* DPadJumpCVarName(int playerIndex);
+const char* AnalogRemapCVarName(int playerIndex);
+const char* AnalogRemapDeadzoneCVarName(int playerIndex);
+const char* AnalogRemapRangeCVarName(int playerIndex);
 }
 }
 #endif

--- a/port/gui/PortMenu.cpp
+++ b/port/gui/PortMenu.cpp
@@ -339,67 +339,71 @@ void PortMenu::AddMenuSettings() {
                      .ComboMap(kHitboxViewMap)
                      .DefaultIndex(0));
 
-    AddWidget(path, "Per-Port Enhancements", WIDGET_SEPARATOR_TEXT);
+    // --- Controls sidebar: per-player input remapping ---
+    path.sidebarName = "Controls";
+    path.column = SECTION_COLUMN_1;
+    AddSidebarEntry("Settings", "Controls", 1);
 
-    // --- Player 1 ---
-    AddWidget(path, "Player 1", WIDGET_SEPARATOR_TEXT);
-    AddWidget(path, "Disable Tap Jump (P1)", WIDGET_CVAR_CHECKBOX)
-        .CVar(enhancements::TapJumpCVarName(0))
-        .RaceDisable(false)
-        .Options(CheckboxOptions().Tooltip("Disables jumping by pushing up on the analog stick."));
-    AddWidget(path, "C-Stick Smash (P1)", WIDGET_CVAR_CHECKBOX)
-        .CVar(enhancements::CStickSmashCVarName(0))
-        .RaceDisable(false)
-        .Options(CheckboxOptions().Tooltip("Replaces C-Button inputs with instant smash attacks."));
-    AddWidget(path, "D-Pad to Jump (P1)", WIDGET_CVAR_CHECKBOX)
-        .CVar(enhancements::DPadJumpCVarName(0))
-        .RaceDisable(false)
-        .Options(CheckboxOptions().Tooltip("Translates N64 D-Pad inputs into C-Up (Jump)."));
+    for (int p = 0; p < PORT_ENHANCEMENT_MAX_PLAYERS; ++p) {
+        const std::string playerLabel = fmt::format("Player {}", p + 1);
+        AddWidget(path, playerLabel, WIDGET_SEPARATOR_TEXT);
 
-    // --- Player 2 ---
-    AddWidget(path, "Player 2", WIDGET_SEPARATOR_TEXT);
-    AddWidget(path, "Disable Tap Jump (P2)", WIDGET_CVAR_CHECKBOX)
-        .CVar(enhancements::TapJumpCVarName(1))
-        .RaceDisable(false)
-        .Options(CheckboxOptions().Tooltip("Same as P1, applied to player 2."));
-    AddWidget(path, "C-Stick Smash (P2)", WIDGET_CVAR_CHECKBOX)
-        .CVar(enhancements::CStickSmashCVarName(1))
-        .RaceDisable(false)
-        .Options(CheckboxOptions().Tooltip("Same as P1, applied to player 2."));
-    AddWidget(path, "D-Pad to Jump (P2)", WIDGET_CVAR_CHECKBOX)
-        .CVar(enhancements::DPadJumpCVarName(1))
-        .RaceDisable(false)
-        .Options(CheckboxOptions().Tooltip("Same as P1, applied to player 2."));
+        AddWidget(path, fmt::format("Disable Tap Jump (P{})", p + 1), WIDGET_CVAR_CHECKBOX)
+            .CVar(enhancements::TapJumpCVarName(p))
+            .RaceDisable(false)
+            .Options(CheckboxOptions().Tooltip("Disables jumping by pushing up on the analog stick."));
 
-    // --- Player 3 ---
-    AddWidget(path, "Player 3", WIDGET_SEPARATOR_TEXT);
-    AddWidget(path, "Disable Tap Jump (P3)", WIDGET_CVAR_CHECKBOX)
-        .CVar(enhancements::TapJumpCVarName(2))
-        .RaceDisable(false)
-        .Options(CheckboxOptions().Tooltip("Same as P1, applied to player 3."));
-    AddWidget(path, "C-Stick Smash (P3)", WIDGET_CVAR_CHECKBOX)
-        .CVar(enhancements::CStickSmashCVarName(2))
-        .RaceDisable(false)
-        .Options(CheckboxOptions().Tooltip("Same as P1, applied to player 3."));
-    AddWidget(path, "D-Pad to Jump (P3)", WIDGET_CVAR_CHECKBOX)
-        .CVar(enhancements::DPadJumpCVarName(2))
-        .RaceDisable(false)
-        .Options(CheckboxOptions().Tooltip("Same as P1, applied to player 3."));
+        AddWidget(path, fmt::format("C-Stick Smash (P{})", p + 1), WIDGET_CVAR_CHECKBOX)
+            .CVar(enhancements::CStickSmashCVarName(p))
+            .RaceDisable(false)
+            .Options(CheckboxOptions().Tooltip("Replaces C-Button inputs with instant smash attacks."));
 
-    // --- Player 4 ---
-    AddWidget(path, "Player 4", WIDGET_SEPARATOR_TEXT);
-    AddWidget(path, "Disable Tap Jump (P4)", WIDGET_CVAR_CHECKBOX)
-        .CVar(enhancements::TapJumpCVarName(3))
-        .RaceDisable(false)
-        .Options(CheckboxOptions().Tooltip("Same as P1, applied to player 4."));
-    AddWidget(path, "C-Stick Smash (P4)", WIDGET_CVAR_CHECKBOX)
-        .CVar(enhancements::CStickSmashCVarName(3))
-        .RaceDisable(false)
-        .Options(CheckboxOptions().Tooltip("Same as P1, applied to player 4."));
-    AddWidget(path, "D-Pad to Jump (P4)", WIDGET_CVAR_CHECKBOX)
-        .CVar(enhancements::DPadJumpCVarName(3))
-        .RaceDisable(false)
-        .Options(CheckboxOptions().Tooltip("Same as P1, applied to player 4."));
+        AddWidget(path, fmt::format("D-Pad to Jump (P{})", p + 1), WIDGET_CVAR_CHECKBOX)
+            .CVar(enhancements::DPadJumpCVarName(p))
+            .RaceDisable(false)
+            .Options(CheckboxOptions().Tooltip("Translates N64 D-Pad inputs into C-Up (Jump)."));
+
+        AddWidget(path, fmt::format("NRage Analog Stick Remap (P{})", p + 1), WIDGET_CVAR_CHECKBOX)
+            .CVar(enhancements::AnalogRemapCVarName(p))
+            .RaceDisable(false)
+            .Options(CheckboxOptions().Tooltip(
+                "When ON: replaces libultraship's stick processing with the NRage per-axis "
+                "deadzone+range formula (no octagonal gate, no radial deadzone, no notch snap). "
+                "When OFF: libultraship's stock pipeline runs unchanged. Both schemes coexist; "
+                "this toggle picks which one runs for this player."));
+
+        const char* deadzoneCVar = enhancements::AnalogRemapDeadzoneCVarName(p);
+        const char* enableCVar   = enhancements::AnalogRemapCVarName(p);
+        AddWidget(path, fmt::format("Remap Deadzone (P{})", p + 1), WIDGET_CVAR_SLIDER_FLOAT)
+            .CVar(deadzoneCVar)
+            .RaceDisable(false)
+            .PreFunc([enableCVar](WidgetInfo& info) {
+                if (!CVarGetInteger(enableCVar, 0)) {
+                    info.options->disabled = true;
+                    info.options->disabledTooltip = "Enable NRage Analog Stick Remap to adjust this.";
+                }
+            })
+            .Options(FloatSliderOptions()
+                         .Min(0.0f).Max(0.99f).DefaultValue(0.10f)
+                         .IsPercentage()
+                         .Tooltip("Per-axis deadzone (0–99%). Inputs inside this fraction of "
+                                  "max deflection on each axis read as 0."));
+
+        const char* rangeCVar = enhancements::AnalogRemapRangeCVarName(p);
+        AddWidget(path, fmt::format("Remap Range (P{})", p + 1), WIDGET_CVAR_SLIDER_FLOAT)
+            .CVar(rangeCVar)
+            .RaceDisable(false)
+            .PreFunc([enableCVar](WidgetInfo& info) {
+                if (!CVarGetInteger(enableCVar, 0)) {
+                    info.options->disabled = true;
+                    info.options->disabledTooltip = "Enable NRage Analog Stick Remap to adjust this.";
+                }
+            })
+            .Options(FloatSliderOptions()
+                         .Min(0.5f).Max(1.5f).DefaultValue(1.0f)
+                         .IsPercentage()
+                         .Tooltip("Output scale (50–150%). 100% caps at the N64's natural max."));
+    }
 }
 
 void PortMenu::AddMenuWindows() {

--- a/src/sys/controller.c
+++ b/src/sys/controller.c
@@ -183,6 +183,17 @@ void syControllerUpdateGlobalData(void)
             gSYControllerDevices[i].stick_range.x = sSYControllerDescs[i].unk0E;
             gSYControllerDevices[i].stick_range.y = sSYControllerDescs[i].unk0F;
 
+            // NRage-style per-axis stick remap. Runs unconditionally (also in
+            // menus / CSS) because the formula is the user's chosen stick
+            // shaping. No-op when the per-player toggle is off — LUS's stock
+            // octagon-clamped output flows through unchanged in that case.
+            // Must come BEFORE c_stick_smash so the synthetic ±80 values that
+            // c_stick_smash writes into stick_range are not subsequently
+            // re-rescaled by our deadzone/range formula.
+            port_enhancement_analog_remap(i,
+                &gSYControllerDevices[i].stick_range.x,
+                &gSYControllerDevices[i].stick_range.y);
+
             // Apply input remap enhancements only during gameplay. The
             // BattleState->players[] array is only valid in VS / 1P scenes;
             // it's NULL in menus / CSS / opening / staffroll, and we must


### PR DESCRIPTION
## Summary

- **New per-player Analog Stick Remap** that perfectly replicates the per-axis deadzone+range formula from [`Ownasaurus/USBtoN64v2`](https://github.com/Ownasaurus/USBtoN64v2/blob/master/Source%20Code/Middlewares/ST/STM32_USB_Host_Library/Class/XPAD/Src/usbh_xpad.c#L260) — the algorithm NRage's "Move Analog Stick" plugin uses.
- **Both control schemes coexist.** Toggle OFF (default) → libultraship's stock pipeline runs unchanged (circular deadzone + octagonal-gate clamp + notch snap). Toggle ON → that output is discarded for the port and recomputed from the raw per-direction axis magnitudes — per-axis deadzone, per-axis linear rescale, no octagon, no notch snap. The asymmetric negative branch (`-(in+1)`) from the source is faithfully preserved.
- **New Settings → Controls sidebar.** Tap Jump / C-Stick Smash / D-Pad Jump are moved here from the Gameplay sidebar; the new remap toggle plus Deadzone (0–99%, default 10%) and Range (50–150%, default 100%) sliders join them. Sliders grey out with an explanatory tooltip when the toggle is off.

## Implementation notes

- libultraship's `ControllerStick::Process()` bakes circular deadzone, octagonal-gate clamp, and notch snap into one non-bypassable pipeline. To replicate the source's per-axis behavior cleanly, the companion libultraship bump (`378e4ee7`) promotes `ControllerStick::GetAxisDirectionValue` from `private` to `public` — one-line declaration move, no behavioral change to LUS itself.
- `port_enhancement_analog_remap` runs **outside** the `gSCManagerBattleState != NULL` gameplay-only guard (so menus/CSS also benefit) and **before** `port_enhancement_c_stick_smash` (so its synthetic ±80 stick values are not subsequently re-rescaled).

## Test plan

- [x] Clean build of `ssb64` target (Debug, `-j 4`) — no new warnings
- [x] Boots cleanly, ran ~115s / 6879 frames in active match without crashes
- [ ] **Sidebar layout:** Settings → Controls present; Tap Jump / C-Stick / D-Pad widgets moved here from Gameplay; per-player blocks show toggle + greyed Deadzone + greyed Range when off
- [ ] **Both schemes coexist:** with LUS deadzone set high (e.g. 50%), small deflections die when toggle OFF; same deflections register when toggle ON for that player only
- [ ] **Octagon override visible:** toggle ON, push P1 stick fully diagonal — both `stick_x`/`stick_y` reach max simultaneously; toggle OFF, diagonals get clamped (X+Y both reduced)
- [ ] **Slider effects:** Deadzone=0%, Range=100% → smooth raw response; Deadzone=50% → small deflections die; Range=150% → fighter saturates faster
- [ ] **Persistence:** non-default toggle/slider state survives a restart
- [ ] **Existing remaps still work** after the move (Tap Jump / C-Stick Smash / D-Pad Jump unchanged)

🤖 Generated with [Claude Code](https://claude.com/claude-code)