### PR TITLE
feat: native Raphnet N64 USB adapter support (multichannel)

### DIFF
--- a/port/port.cpp
+++ b/port/port.cpp
@@ -459,6 +459,13 @@ void PortShutdown(void) {
 	// kernel runs the effect to completion after the process exits.
 	if (sContext) {
 		if (auto cd = sContext->GetControlDeck()) {
+			// Shut down the raphnet pipeline FIRST. Each transport's Close
+			// sends RQ_RNT_SUSPEND_POLLING(0) so the adapter is usable as a
+			// plain HID joystick again after process exit (the firmware does
+			// NOT auto-resume on hid_close). Order: ShutdownRaphnet → Stop-
+			// AllRumble → sContext.reset() — same singleton-reentry caveat
+			// applies as the rumble cleanup below.
+			cd->ShutdownRaphnet();
 			cd->StopAllRumble();
 		}
 	}


### PR DESCRIPTION
Closes #90

## Summary

- Adds a hidapi-based driver for raphnet's [gc_n64_usb-v3 adapter](https://github.com/raphnet/gc_n64_usb-v3) so OEM N64 controllers connect via the adapter's vendor command interface instead of SDL's generic HID joystick path. Gives raw N64 SI status (full s8 stick range, exact button bit layout) and native rumble pak control via `RQ_RNT_SET_VIBRATION`.
- Supports both single-port and **4-channel adapters**: the manager probes each channel for `CTL_TYPE_N64`, builds a candidate list, and claims game ports deterministically by sorted `(serial, channel)` so plug order doesn't change port assignments across reboots. Multiple separate adapters on the same host also work (4 separate adapters → 4 game ports).
- Safely off when no adapter is connected (no-op enumerate). Three CVARs for opt-in/out and remote diagnostics: `gControllers.Raphnet.Enabled` (master switch), `gControllers.Raphnet.SelfTest` (one-shot diagnostic dump for tester bug reports), `gControllers.PortN.RaphnetSerial` (per-port serial pin for users with multiple adapters).

## Architecture

```
osContInit
  └─ ControlDeck::PreInitRaphnet         ◀── BEFORE SDL_Init (Windows DirectInput grab race)
       ├─ hid_init()
       ├─ hid_enumerate over VIDs 0x289b/0x1781/0x1740 (interface ≥ 1)
       ├─ open each → boot sequence: SUSPEND_POLLING(0) → GET_VERSION → SUSPEND_POLLING(1)
       ├─ probe channels with GET_CONTROLLER_TYPE, claim N64-reporting channels
       ├─ deterministic port assignment by sorted (serial, channel)
       └─ tell ConnectedPhysicalDeviceManager to skip-list claimed VIDs (so SDL doesn't grab the joystick interface)

osContGetReadData
  └─ LUS::Controller::ReadToOSContPad
       └─ if mRaphnetBindingActive:
            └─ transport->Poll(channel, &pad)   ◀── raw SI N64_GET_STATUS, decodes 4 bytes
                                                    (bypasses mappings AND mPadBuffer)

PortShutdown
  ├─ portAudioShutdownAssets
  ├─ ControlDeck::ShutdownRaphnet         ◀── NEW: SET_VIBRATION 0 + SUSPEND_POLLING(0) + close
  ├─ ControlDeck::StopAllRumble           ◀── existing (PR #87)
  └─ sContext.reset()
```

The Raphnet path is **per-port**, not global — claimed ports use native polling, unclaimed ports keep the existing keyboard/SDL mapping pipeline. Mixing a real N64 controller via Raphnet on port 1 with a USB Pro Controller on port 2 just works.

C-Stick Smash and D-Pad Jump enhancements (PR #92) operate on `gSYControllerDevices` AFTER libultraship hands the pad over, so they're source-agnostic and apply to Raphnet inputs the same way (gated by per-player CVAR, default off — preserves authentic N64 behavior on real hardware unless the user opts in).

## Dependencies

- Vendors `libusb/hidapi` at `hidapi-0.14.0` via `FetchContent` in libultraship's `cmake/dependencies/common.cmake`. Static-only build, hidraw backend on Linux (no libusb-1.0 runtime dep), IOKit on macOS, hid.dll on Windows. Sets `CMAKE_POLICY_VERSION_MINIMUM=3.5` around hidapi's add_subdirectory because hidapi declares `cmake_minimum_required(3.4.3)` which CMake 4.x rejects.

## Implementation notes / non-obvious decisions

- **No simulated-input-lag on Raphnet ports**: `LUS::Controller::ReadToOSContPad` skips `mPadBuffer` for native ports. `CVAR_SIMULATED_INPUT_LAG` exists to *add* configurable lag on top of an emulator's near-zero input latency; native USB polling already reflects whatever the OS imposes (~1 ms common case), so combining the two would double-count. Logged once at INFO when the binding is installed.
- **Firmware doesn't auto-resume polling on hid_close**, so `RaphnetTransport::Close` explicitly sends `SUSPEND_POLLING(0)`. Without this, a process that exits leaves the firmware wedged until next physical replug.
- **Self-heal on Open**: `SUSPEND_POLLING(0)` is sent defensively before `GET_VERSION` so a prior process that crashed mid-session (kill -9 etc.) doesn't render the adapter unusable on the next launch.
- **Frame-budget concern**: `hid_get_feature_report` is synchronous on every backend (`hid_set_nonblocking` only affects `hid_read`). Real adapter responds in <1 ms; a wedged adapter could stall up to the OS-level USB timeout (~5 s). Documented; if remote testers report stalls we can add a polling thread in a follow-up.
- **Destructor singleton-reentry trap** (project memory `project_libultraship_destructor_singleton_reentry.md`): `RaphnetRumbleMapping`'s destructor does NOT touch the transport; cleanup is double-protected via `ShutdownRaphnet` + `StopAllRumble`. `weak_ptr<RaphnetTransport>` decays cleanly when the manager closes the transport.
- **Older firmware**: `RQ_RNT_GET_CONTROLLER_TYPE` was added in v3.4. Older v3.x firmware falls through to optimistic claim of channel 0 (logged WARN). v3.0+ required.

## Test plan

### Hardware-free (mock transport, completed)

```
SSB64_RAPHNET_MOCK=N ./BattleShip   # N = 1..4
```

The mock skips `hid_open_path`, synthesizes Poll responses from SDL keyboard state (WASD = stick, J = A, K = B, Space = Z, Q/E = L/R, Enter = Start, arrows = C-stick), and logs every protocol call. Verified:

- [x] `SSB64_RAPHNET_MOCK=0` (default) — no behavior change vs. main, SDL fallback unchanged
- [x] `SSB64_RAPHNET_MOCK=1` — single mock claims port 0, native polling active, rumble dispatch hits the mock, clean shutdown
- [x] `SSB64_RAPHNET_MOCK=4` — 4 mocks claim ports 0-3 deterministically by serial sort; SDL skip-list applied once for VID 0x289b
- [x] `weak_ptr<RaphnetTransport>` graceful-degrade: `StopAllRumble` after `ShutdownRaphnet` correctly logs `"transport gone, no-op"` rather than crashing
- [x] InputEditorWindow renders the teal "Native Raphnet — no rebinding" banner on claimed ports

### Real hardware (needs a tester with a raphnet gc_n64_usb-v3)

- [ ] No-adapter sanity: launch with adapter unplugged; `ssb64.log` shows `enumerate: 0 adapter command interface(s) found`, normal SDL gamepad path works
- [ ] Single adapter + N64 pad: `ssb64.log` shows version, `chn=0: CTL_TYPE_N64`, port 0 claim, `globally ignoring SDL gamepads with VID 0x289b`, `FIRST poll` with full bytes
- [ ] In-game: A / B / Z / L / R / Start / C-stick / D-pad / analog stick all work via real controller; full s8 stick range
- [ ] After clean exit: adapter is immediately usable as plain HID joystick (no replug needed) — validates `SUSPEND_POLLING(0)` on Close
- [ ] Self-heal from prior crash: `kill -9 BattleShip` mid-session, relaunch — log shows successful enumeration (defensive `SUSPEND_POLLING(0)` on Open recovers)
- [ ] `gControllers.Raphnet.SelfTest=1` runs full diagnostic dump (version, all 4 channel CTL_TYPEs, 10 polls/channel with bytes, 100 ms vibration test) into `ssb64.log` — single-step bug report flow
- [ ] `gControllers.Raphnet.Enabled=0` falls back to SDL HID joystick mode cleanly
- [ ] 4-port adapter (if a tester has one): all 4 ports populate from a single adapter's 4 channels

### Cross-platform build

- [x] macOS arm64 Debug clean
- [ ] Linux Debug (needs `libudev-dev` for hidapi's hidraw backend)
- [ ] Windows MSVC Debug

🤖 Generated with [Claude Code](https://claude.com/claude-code)
