### PR TITLE
Fix Race to the Finish crash: NULL-guard FTKirbyCopy fixup for N-Kirby (#101)

### DIFF
--- a/src/ft/ftmanager.c
+++ b/src/ft/ftmanager.c
@@ -682,7 +682,19 @@ void ftManagerInitFighter(GObj *fighter_gobj, FTDesc *desc)
              * polygon-Kirby on 1P stage 12 uses real Kirby's AI attack table and
              * fires neutral-B at any nearby polygon, so its eat path also reads
              * copy[fkind] — must be fixed up even when the player isn't Kirby.
-             * Idempotent via sStructU16Fixups. */
+             * Idempotent via sStructU16Fixups.
+             *
+             * NULL guard: the FTKirbyCopy table lives in Kirby's main-motion file,
+             * which is only loaded under `gFTDataKirbyMainMotion` when real Kirby
+             * is on the stage.  N-Kirby's FTData loads the same physical file but
+             * stores it under `gFTDataNKirbySubMotion` instead, so on stages with
+             * polygon Kirby and no real Kirby (e.g. Race to the Finish randomly
+             * picking N-Kirby as one of the three polygon enemies) the lookup
+             * returns NULL+0=NULL.  Skip the fixup in that case — the eat-path
+             * consumer in ftkirbyspecialn.c reads from the same NULL global so
+             * polygon Kirby cannot actually invoke the inhale code path there
+             * either; the N64 build relies on the same precondition. */
+            if (copy != NULL)
             {
                 s32 i;
                 for (i = 0; i < nFTKindEnumCount; i++)


### PR DESCRIPTION
## Summary
- Fixes #101 — `portFixupStructU16+0x230` `fault_addr=0x0` SIGSEGV on Race to the Finish completion in v0.7-beta
- N-Kirby (`fkind=22`) is one of the randomized polygon enemies. Commit `d47a021` removed the `fp->fkind == nFTKindKirby` gate on the FTKirbyCopy fixup loop so polygon-Kirby's inhale would see rotated entries — but the table is loaded via `gFTDataKirbyMainMotion`, which is only populated when **real Kirby** is on the stage. N-Kirby's FTData loads the same file under `gFTDataNKirbySubMotion`, so on Kirby-less stages `lbRelocGetFileData(...) = NULL+0 = NULL` (`llKirbyMainMotionSpecialNFTKirbyCopy == 0x0`), and the fixup loop writes through NULL.
- Fix: NULL-guard the fixup loop. The eat-path consumer in `ftkirbyspecialn.c` reads from the same global, so the polygon Kirby inhale flow cannot actually reach `copy[fkind]` here either — the original N64 build relies on the same precondition.

## Test plan
- [x] Worktree builds clean (`cmake --build .../build --target ssb64 -j 4`)
- [x] BattleShip boots and shuts down clean (no startup regressions)
- [ ] Manual repro: complete Race to the Finish where N-Kirby is in the random polygon trio (3-in-12 chance per run) — should no longer SIGSEGV
- [ ] Sanity: real Kirby on a normal stage still triggers the fixup (regression check for d47a021's original Giant DK / polygon team fix)

🤖 Generated with [Claude Code](https://claude.com/claude-code)