### PR TITLE
Fix #96: NRage analog-remap deadzone/range crash + harden Config::Save

### DIFF
--- a/port/enhancements/enhancements.cpp
+++ b/port/enhancements/enhancements.cpp
@@ -42,11 +42,17 @@ constexpr const char* kDPadJumpCVars[PORT_ENHANCEMENT_MAX_PLAYERS] = {
 // magnitudes via the per-axis formula in
 // usbh_xpad.c (Ownasaurus/USBtoN64v2). Disabled by default; the LUS pipeline
 // (circular deadzone + octagonal gate + notch snap) runs unchanged when off.
+// Enable key has to live UNDER PX (as a sibling of Deadzone/Range), not AT PX.
+// The config layer stores cvars in flattened JSON-pointer form and unflattens
+// on every save; if PX were both a scalar (the enable flag) and a parent of
+// PX.Deadzone / PX.Range, nlohmann's unflatten throws type_error.313 on the
+// next save and Config::Save truncates the file to empty before serializing,
+// wiping the user's settings (issue #96).
 constexpr const char* kAnalogRemapEnableCVars[PORT_ENHANCEMENT_MAX_PLAYERS] = {
-    "gEnhancements.AnalogRemap.P1",
-    "gEnhancements.AnalogRemap.P2",
-    "gEnhancements.AnalogRemap.P3",
-    "gEnhancements.AnalogRemap.P4",
+    "gEnhancements.AnalogRemap.P1.Enabled",
+    "gEnhancements.AnalogRemap.P2.Enabled",
+    "gEnhancements.AnalogRemap.P3.Enabled",
+    "gEnhancements.AnalogRemap.P4.Enabled",
 };
 constexpr const char* kAnalogRemapDeadzoneCVars[PORT_ENHANCEMENT_MAX_PLAYERS] = {
     "gEnhancements.AnalogRemap.P1.Deadzone",

--- a/port/port.cpp
+++ b/port/port.cpp
@@ -256,6 +256,28 @@ static int PortInitImpl(int argc, char* argv[]) {
 		cv->SetFloat("gAdvancedResolution.AspectRatioX", 4.0f);
 		cv->SetFloat("gAdvancedResolution.AspectRatioY", 3.0f);
 		cv->SetInteger("gAdvancedResolution.Enabled", 1);
+
+		/* Issue #96 migration. v0.7-beta stored the per-player NRage
+		 * analog-remap enable flag at gEnhancements.AnalogRemap.PX —
+		 * the same JSON path that PX.Deadzone / PX.Range hang off of.
+		 * That made PX both a scalar and a parent, and Config::Save's
+		 * unflatten() threw json::type_error.313 the first time the
+		 * Deadzone or Range slider moved, truncating the file to
+		 * empty before the throw. The enable cvar is now stored at
+		 * gEnhancements.AnalogRemap.PX.Enabled (sibling of Deadzone
+		 * / Range). Migrate any legacy scalar by copying its value
+		 * to the new key and clearing the old key, otherwise the
+		 * legacy entry would re-introduce the conflict on next save. */
+		for (int p = 0; p < 4; ++p) {
+			char legacy[64];
+			char modern[64];
+			std::snprintf(legacy, sizeof(legacy), "gEnhancements.AnalogRemap.P%d", p + 1);
+			std::snprintf(modern, sizeof(modern), "gEnhancements.AnalogRemap.P%d.Enabled", p + 1);
+			if (auto var = cv->Get(legacy); var && var->Type == Ship::ConsoleVariableType::Integer) {
+				cv->SetInteger(modern, var->Integer);
+				cv->ClearVariable(legacy);
+			}
+		}
 	}
 
 #ifdef __APPLE__


### PR DESCRIPTION
Fixes #96.

## Summary
- Per-player NRage analog-remap enable cvar moved from `gEnhancements.AnalogRemap.PX` (scalar leaf) to `gEnhancements.AnalogRemap.PX.Enabled` (sibling of Deadzone/Range), so the path is no longer both a scalar and a parent.
- Startup migration in `PortInitImpl` copies any legacy integer scalar at the old path to the new one and clears the old key.
- Submodule bump: libultraship `Config::Save` now serializes to a string *before* opening the file, so a future cvar-naming bug can't silently truncate the user's config to zero bytes. (PR: JRickey/libultraship#TBD — branch `ssb64-config-save-atomic`, already merged into `ssb64`.)

## Root cause
v0.7-beta stored:
- `gEnhancements.AnalogRemap.P1` = 1 (enable, integer)
- `gEnhancements.AnalogRemap.P1.Deadzone` = 0.10 (float)
- `gEnhancements.AnalogRemap.P1.Range` = 1.0 (float)

The cvar layer flattens these to `/CVars/.../AnalogRemap/P1`, `/CVars/.../AnalogRemap/P1/Deadzone`, `/CVars/.../AnalogRemap/P1/Range` and calls `nlohmann::json::unflatten()` on every save. Once both the scalar `P1` and child `P1/Deadzone` exist, unflatten throws `type_error.313`. Worse, `Config::Save` opened the ofstream (truncating the file) *before* serializing — so the user's whole config was wiped before the throw propagated.

## Test plan
- [x] Build clean on macOS (`cmake --build build --target ssb64 -j 4`)
- [x] Synthetic legacy config (`{"P1": 1, "P2": 0}`) → after launch, file shows `{"P1": {"Enabled": 1}, "P2": {"Enabled": 0}}` and the rest of the cvars are intact (no truncation, no crash)
- [ ] Linux user reproduction — toggle remap, move Deadzone slider, confirm no crash + settings persist
- [ ] Existing user with legacy v0.7-beta config that hadn't crashed yet — confirm one-shot migration runs and the toggle state survives

🤖 Generated with [Claude Code](https://claude.com/claude-code)