### PR TITLE
Issue #103: free prev scene arena, widen token generation, clear long-lived GObj pointers

### DIFF
--- a/port/resource/RelocPointerTable.cpp
+++ b/port/resource/RelocPointerTable.cpp
@@ -8,22 +8,32 @@
  * Flat array mapping token index → pointer.
  * Index 0 is reserved (NULL token). Valid indices start at 1.
  *
- * Tokens include an 8-bit generation in the high byte. This prevents a stale
- * token from an old scene from resolving to a new scene's pointer after reset.
+ * Token layout: [12 bits generation][20 bits index]
+ *   - 4096 generations before wrap (vs the previous 128, which a long
+ *     classic-mode session can blow through in under an hour — at which
+ *     point a stale token whose generation byte coincidentally re-matches
+ *     resolves through the current table and returns whatever pointer
+ *     happens to live at that index now). 4096 generations is days of
+ *     continuous play — effectively infinite for real users.
+ *   - 1M indices per scene. Old layout allowed 16M; real measurements
+ *     show typical usage well under 100K, so 1M leaves 10x headroom.
+ *     Anything that registers >1M tokens in a single scene needs a real
+ *     conversation about why before we widen this back.
  *
- * Initial capacity: 256K entries (~2 MB). Grows by doubling if needed.
- * Typical usage per scene is well under 100K tokens.
+ * Initial capacity: 256K entries (~2 MB). Grows by doubling if needed,
+ * capped at TOKEN_INDEX_MASK (1M).
  */
 
 static void **sPointerTable = nullptr;
 static uint32_t sNextIndex = 1;
 static uint32_t sCapacity = 0;
-static uint32_t sGeneration = 0x80;
+static uint32_t sGeneration = 0x080;
 
 static constexpr uint32_t INITIAL_CAPACITY = 256 * 1024;
-static constexpr uint32_t TOKEN_GENERATION_SHIFT = 24;
-static constexpr uint32_t TOKEN_INDEX_MASK = 0x00FFFFFF;
-static constexpr uint32_t TOKEN_GENERATION_MIN = 0x80;
+static constexpr uint32_t TOKEN_GENERATION_SHIFT = 20;
+static constexpr uint32_t TOKEN_INDEX_MASK = 0x000FFFFF;     // 20 bits = 1M-1
+static constexpr uint32_t TOKEN_GENERATION_MAX = 0xFFF;      // 12 bits
+static constexpr uint32_t TOKEN_GENERATION_MIN = 0x080;
 
 static void ensureCapacity(void)
 {
@@ -101,13 +111,13 @@ void *portRelocResolvePointerDebug(uint32_t token, const char *file, int line)
 		if (file != nullptr)
 		{
 			spdlog::error("RelocPointerTable: invalid/stale token 0x{:08X} "
-			              "(generation=0x{:02X}, max_index={}, caller={}:{})",
+			              "(generation=0x{:03X}, max_index={}, caller={}:{})",
 			              token, sGeneration, sNextIndex - 1, file, line);
 		}
 		else
 		{
 			spdlog::error("RelocPointerTable: invalid/stale token 0x{:08X} "
-			              "(generation=0x{:02X}, max_index={})",
+			              "(generation=0x{:03X}, max_index={})",
 			              token, sGeneration, sNextIndex - 1);
 		}
 		return nullptr;
@@ -131,7 +141,7 @@ void portRelocResetPointerTable(void)
 {
 	sNextIndex = 1;
 	sGeneration++;
-	if (sGeneration > 0xFF)
+	if (sGeneration > TOKEN_GENERATION_MAX)
 	{
 		sGeneration = TOKEN_GENERATION_MIN;
 	}

--- a/src/mn/mn1pmode/mn1pcontinue.c
+++ b/src/mn/mn1pmode/mn1pcontinue.c
@@ -1191,6 +1191,15 @@ void mnPlayers1PGameContinueFuncStart(void)
     s32 unused;
     LBRelocSetup rl_setup;
 
+#ifdef PORT
+    /* Issue #103: sMN1PContinueFighterGObj and sMN1PContinueFigatreeHeap are
+     * static globals that survive scene transitions; the previous instance
+     * left them holding pointers into a now-freed scene arena. Clear before
+     * mnPlayers1PGameContinueFuncRun assigns the new fighter at line 348. */
+    sMN1PContinueFighterGObj = NULL;
+    sMN1PContinueFigatreeHeap = NULL;
+#endif
+
     rl_setup.table_addr = (uintptr_t)&lLBRelocTableAddr;
     rl_setup.table_files_num = (u32)llRelocFileCount;
     rl_setup.file_heap = NULL;

--- a/src/mn/mnplayers/mnplayersvs.c
+++ b/src/mn/mnplayers/mnplayersvs.c
@@ -4641,6 +4641,23 @@ void mnPlayersVSInitPlayer(s32 player)
 	sMNPlayersVSSlots[player].p_sfx = NULL;
 	sMNPlayersVSSlots[player].sfx_id = 0;
 	sMNPlayersVSSlots[player].player = NULL;
+#ifdef PORT
+	/* Issue #103: the original decomp clears `player` and the secondary GObj
+	 * pointers above but leaves the seven primary GObj fields below pointing
+	 * at the previous CSS scene's GObjs. On N64 the old GObj pool is reset
+	 * before re-entry so those addresses are harmless; on the port the pool
+	 * lives in the prior scene's arena which taskman.c now frees, so any
+	 * stale pointer here is a freed-arena deref next time something reads it.
+	 * Clear them on every slot init. */
+	sMNPlayersVSSlots[player].cursor = NULL;
+	sMNPlayersVSSlots[player].puck = NULL;
+	sMNPlayersVSSlots[player].type_button = NULL;
+	sMNPlayersVSSlots[player].name_emblem_gobj = NULL;
+	sMNPlayersVSSlots[player].panel_doors = NULL;
+	sMNPlayersVSSlots[player].panel = NULL;
+	sMNPlayersVSSlots[player].type = NULL;
+	sMNPlayersVSSlots[player].figatree_heap = NULL;
+#endif
 	sMNPlayersVSSlots[player].fkind = gSCManagerTransferBattleState.players[player].fkind;
 
 	if ((gSCManagerTransferBattleState.players[player].pkind == nFTPlayerKindMan) && (sMNPlayersVSControllerOrders[player] == -1))

--- a/src/mn/mnvsmode/mnvsresults.c
+++ b/src/mn/mnvsmode/mnvsresults.c
@@ -3334,6 +3334,21 @@ void mnVSResultsFuncStart(void)
 	LBRelocSetup rl_setup;
 	s32 i;
 
+#ifdef PORT
+	/* Issue #103: sMNVSResultsFighterGObjs and sMNVSResultsFigatreeHeaps are
+	 * static (BSS) arrays that survive scene transitions. The previous
+	 * results-screen instance left them holding pointers into that scene's
+	 * arena, which taskman.c now frees at the next scene transition — any
+	 * read before mnVSResultsMakeFighter rewrites the slot at line 993
+	 * dereferences freed host memory. Clear them here before any other
+	 * results-scene state is set up. */
+	for (i = 0; i < ARRAY_COUNT(sMNVSResultsFighterGObjs); i++)
+	{
+		sMNVSResultsFighterGObjs[i] = NULL;
+		sMNVSResultsFigatreeHeaps[i] = NULL;
+	}
+#endif
+
 	rl_setup.table_addr = (uintptr_t)&lLBRelocTableAddr;
 	rl_setup.table_files_num = (u32)llRelocFileCount;
 	rl_setup.file_heap = NULL;

--- a/src/sc/scmanager.c
+++ b/src/sc/scmanager.c
@@ -939,6 +939,23 @@ void scManagerRunLoop(sb32 arg)
 #ifdef PORT
 		port_log("SSB64: scManagerRunLoop — entering scene %d\n",
 		         (int)gSCManagerSceneData.scene_curr);
+
+		/* Issue #103 defence: clear cross-scene GObj pointers in the three
+		 * persistent battle-state structs before dispatching the next scene.
+		 * `fighter_gobj` is the only field in SCPlayerData that holds a host
+		 * pointer; it's set at fighter spawn (ftparam.c:197 in movie scenes,
+		 * and via FTStruct linkage in the regular battle path), survives the
+		 * battle scene's arena, and is read across scenes in callbacks like
+		 * ftshadow.c:107 and ftcomputer.c:5623. With taskman.c's prev-arena
+		 * free in place those reads now SIGSEGV at the read site instead of
+		 * hitting plausible-looking stale data. NULL the slot at the scene
+		 * boundary so the read just yields NULL (which the consumers already
+		 * gate on, e.g. controller.c:208). */
+		for (s32 _p = 0; _p < GMCOMMON_PLAYERS_MAX; _p++) {
+			gSCManager1PGameBattleState.players[_p].fighter_gobj = NULL;
+			gSCManagerVSBattleState.players[_p].fighter_gobj = NULL;
+			gSCManagerTransferBattleState.players[_p].fighter_gobj = NULL;
+		}
 #endif
 		switch (gSCManagerSceneData.scene_curr)
 		{

--- a/src/sys/taskman.c
+++ b/src/sys/taskman.c
@@ -1318,9 +1318,24 @@ void syTaskmanStartTask(SYTaskmanSetup *tsetup)
 	 * symbols. In the host port those symbols are ordinary globals, so their
 	 * relative addresses are not a valid heap on any platform. Use a fresh
 	 * scene heap instead; this keeps scene memory ownership explicit instead
-	 * of relying on host linker layout or allocator reuse. */
+	 * of relying on host linker layout or allocator reuse.
+	 *
+	 * Free the previous scene's arena before allocating a new one. Without
+	 * this each scene transition leaks 16MB to libc and old arenas stay
+	 * mapped (and READABLE) for the rest of the process lifetime — which
+	 * means stale pointers from prior scenes still resolve to plausible-
+	 * looking memory instead of segfaulting at the moment of misuse.
+	 *
+	 * Suspected root cause for issue #103-family crashes: a long-lived
+	 * structure (CSS slot, fighter persistence) holds a pointer or token
+	 * referring to scene-N's arena; scene N+1 reads through it and gets
+	 * stale GBI command bytes or a bogus vertex pointer instead of a clean
+	 * NULL/SIGSEGV that we could trace. Freeing the prev arena turns
+	 * dangling-reference reads into hard faults at the dangling site,
+	 * which is far easier to triage. */
 	{
 		static const size_t kPortHeapSize = 16 * 1024 * 1024;
+		static void *sPrevHeap = NULL;
 		void *heap = malloc(kPortHeapSize);
 		if (heap == NULL)
 		{
@@ -1331,6 +1346,12 @@ void syTaskmanStartTask(SYTaskmanSetup *tsetup)
 		port_log("SSB64: syTaskmanStartTask — decomp arena_start=%p arena_size=0x%llx (ignored on PORT)\n",
 		         tsetup->scene_setup.arena_start,
 		         (unsigned long long)tsetup->scene_setup.arena_size);
+		if (sPrevHeap != NULL)
+		{
+			port_log("SSB64: syTaskmanStartTask — freeing prev PORT heap=%p (16MiB)\n", sPrevHeap);
+			free(sPrevHeap);
+		}
+		sPrevHeap = heap;
 		tsetup->scene_setup.arena_start = heap;
 		tsetup->scene_setup.arena_size = (u32)kPortHeapSize;
 		port_log("SSB64: syTaskmanStartTask — using fresh PORT heap arena_start=%p arena_size=0x%llx\n",


### PR DESCRIPTION
## Summary

Closes the heap-token / generation-cycle aliasing bug class behind issue #103. Three commits, applied in order:

1. **`825de9a` Free prev scene arena in `syTaskmanStartTask`.** The PORT scene-startup allocates a fresh 16 MB arena via libc `malloc` on every scene transition but never freed the previous one. Old arenas stayed mapped & readable, so stale pointers from prior scenes silently resolved to plausible-looking data instead of segfaulting at the dangling site. Track and `free()` the previous arena.
2. **`ef36cf4` Widen reloc-token generation 8 → 12 bits.** `portRelocResetPointerTable` bumps the gen byte every scene. At 8 bits + the reserved-NULL convention, a long classic-mode session blew through all 128 generations in well under an hour; after wrap, a stale token whose gen byte coincidentally re-matched resolved through the current table and returned a wrong pointer. New layout `[12-bit gen][20-bit index]` extends safety to ~4096 generations (days of play) while keeping 1 M indices per scene (10× observed peak).
3. **`f714a0d` Clear long-lived GObj pointers at scene boundaries.** With (1) and (2) in place the dangling reads stop being silent and start crashing at the read site. A `CSS → VS battle → CSS → new VS battle` reproducibly faulted at `mnVSResultsSetPlayerTagPosition` (`mnvsresults.c:1043`). Three Explore-agent audits found four converging suspects — long-lived BSS structures that hold raw `GObj*` across scene transitions and were never cleared:
   - `gSCManager{1PGame,VS,Transfer}BattleState.players[].fighter_gobj` — cross-scene reads in `ftshadow.c:107`, `sc1pgame.c:825`, `sc1pbonusstage.c:846-848`, `itmball.c:392`, `controller.c:208`. Cleared at every `scManagerRunLoop` iteration.
   - `sMNVSResultsFighterGObjs[]` + `sMNVSResultsFigatreeHeaps[]` — zeroed at the top of `mnVSResultsFuncStart`.
   - `sMN1PContinueFighterGObj` + `sMN1PContinueFigatreeHeap` — zeroed at the top of `mnPlayers1PGameContinueFuncStart`.
   - Seven primary GObj fields the decomp's `mnPlayersVSInitPlayer` reset overlooked: `cursor`, `puck`, `type_button`, `name_emblem_gobj`, `panel_doors`, `panel`, `type`, plus `figatree_heap`. Added.

All clears are gated on `PORT` so the decomp's N64 byte-match intent is preserved.

## Mechanism

The two base fixes (1 + 2) are mode-agnostic and close the underlying machinery that lets stale pointers / tokens *masquerade as valid* across scene boundaries. The cleanup patches (3) close the four enumerated structures the audit identified. Together they convert a class of silent-corruption bugs into either a clean NULL (safe consumers gate on it) or a hard SIGSEGV at the actual read site, which is debuggable.

## Test plan

- [x] `cmake --build build/x64 --target ssb64 --config RelWithDebInfo` clean.
- [x] **VS** repro: `CSS → battle → CSS → battle → results screen` no longer crashes.
- [ ] **Classic mode** repro: extended classic-mode session (10+ stage transitions) holds. Patches #1 + #3 directly cover the 1P-flagged sites; if any 1P-specific BSS array is still dangling the new crash will pinpoint it cleanly.
- [ ] OpenGL backend regression check.

🤖 Generated with [Claude Code](https://claude.com/claude-code)