### PR TITLE
Cheat Menu

### DIFF
--- a/port/enhancements/enhancements.cpp
+++ b/port/enhancements/enhancements.cpp
@@ -254,6 +254,17 @@ extern "C" void port_enhancement_dpad_jump(int player_index, unsigned short* but
     }
 }
 
+extern "C" {
+    int port_cheat_unlock_all()        { return CVarGetInteger("gCheats.UnlockAll", 0); }
+    int port_cheat_unlock_luigi()      { return CVarGetInteger("gCheats.UnlockLuigi", 0); }
+    int port_cheat_unlock_ness()       { return CVarGetInteger("gCheats.UnlockNess", 0); }
+    int port_cheat_unlock_captain()    { return CVarGetInteger("gCheats.UnlockCaptain", 0); }
+    int port_cheat_unlock_purin()      { return CVarGetInteger("gCheats.UnlockPurin", 0); }
+    int port_cheat_unlock_inishie()    { return CVarGetInteger("gCheats.UnlockInishie", 0); }
+    int port_cheat_unlock_soundtest()  { return CVarGetInteger("gCheats.UnlockSoundTest", 0); }
+    int port_cheat_unlock_itemswitch() { return CVarGetInteger("gCheats.UnlockItemSwitch", 0); }
+}
+
 namespace ssb64 {
 namespace enhancements {
 

--- a/port/enhancements/enhancements.h
+++ b/port/enhancements/enhancements.h
@@ -50,6 +50,8 @@ void port_enhancement_dpad_jump(int player_index, unsigned short* button_hold, u
 // — both schemes coexist, the toggle picks which runs.
 void port_enhancement_analog_remap(int player_index, signed char* stick_x, signed char* stick_y);
 
+int port_cheat_unlock_all_active(void);
+
 #ifdef __cplusplus
 }
 

--- a/port/gameloop.cpp
+++ b/port/gameloop.cpp
@@ -55,6 +55,8 @@ extern "C" int portFastCaptureBackbufferPNG(const char *path);
  * Implemented in port/stubs/n64_stubs.c. */
 extern "C" void port_vi_simulate_vblank(void);
 
+extern "C" void lbBackupApplyCheats(void);
+
 /* ========================================================================= */
 /*  External game symbols (C linkage)                                        */
 /* ========================================================================= */
@@ -504,6 +506,9 @@ static void port_screenshot_maybe_capture(int frame)
 
 void PortPushFrame(void)
 {
+	// Process cheats safely before the frame updates
+	lbBackupApplyCheats();
+
 	/* Capture the wall-clock start of this PortPushFrame for the
 	 * frame-pacing fallback below. */
 	auto frameStart = std::chrono::steady_clock::now();

--- a/port/gui/PortMenu.cpp
+++ b/port/gui/PortMenu.cpp
@@ -293,28 +293,6 @@ void PortMenu::AddMenuSettings() {
     path.column = SECTION_COLUMN_1;
     AddSidebarEntry("Settings", "Gameplay", 1);
 
-    /*
-    AddWidget(path, "Per-Port Enhancements", WIDGET_SEPARATOR_TEXT);
-    AddWidget(path, "Disable Tap Jump (P1)", WIDGET_CVAR_CHECKBOX)
-        .CVar(enhancements::TapJumpCVarName(0))
-        .RaceDisable(false)
-        .Options(CheckboxOptions().Tooltip(
-            "When enabled, pushing up on the analog stick no longer triggers a jump for player 1. "
-            "Jump buttons (X, Y, C-up, etc.) still work."));
-    AddWidget(path, "Disable Tap Jump (P2)", WIDGET_CVAR_CHECKBOX)
-        .CVar(enhancements::TapJumpCVarName(1))
-        .RaceDisable(false)
-        .Options(CheckboxOptions().Tooltip("Same as P1, applied to player 2."));
-    AddWidget(path, "Disable Tap Jump (P3)", WIDGET_CVAR_CHECKBOX)
-        .CVar(enhancements::TapJumpCVarName(2))
-        .RaceDisable(false)
-        .Options(CheckboxOptions().Tooltip("Same as P1, applied to player 3."));
-    AddWidget(path, "Disable Tap Jump (P4)", WIDGET_CVAR_CHECKBOX)
-        .CVar(enhancements::TapJumpCVarName(3))
-        .RaceDisable(false)
-        .Options(CheckboxOptions().Tooltip("Same as P1, applied to player 4."));
-    */
-
     AddWidget(path, "1P Stage Clear: Frozen Frame Background", WIDGET_CVAR_CHECKBOX)
         .CVar(enhancements::StageClearFrozenWallpaperCVarName())
         .RaceDisable(false)
@@ -418,6 +396,27 @@ void PortMenu::AddMenuSettings() {
                          .IsPercentage()
                          .Tooltip("Output scale (50–150%). 100% caps at the N64's natural max."));
     }
+
+    // --- Cheats ---
+    path.sidebarName = "Cheats";
+    path.column = SECTION_COLUMN_1;
+    AddSidebarEntry("Settings", "Cheats", 1);
+
+    AddWidget(path, "Master Unlocks", WIDGET_SEPARATOR_TEXT);
+    AddWidget(path, "Unlock Everything", WIDGET_CVAR_CHECKBOX)
+    .CVar("gCheats.UnlockAll")
+    .RaceDisable(false);
+
+    AddWidget(path, "Individual Characters", WIDGET_SEPARATOR_TEXT);
+    AddWidget(path, "Unlock Captain Falcon", WIDGET_CVAR_CHECKBOX).CVar("gCheats.UnlockCaptain").RaceDisable(false);
+    AddWidget(path, "Unlock Jigglypuff", WIDGET_CVAR_CHECKBOX).CVar("gCheats.UnlockPurin").RaceDisable(false);
+    AddWidget(path, "Unlock Luigi", WIDGET_CVAR_CHECKBOX).CVar("gCheats.UnlockLuigi").RaceDisable(false);
+    AddWidget(path, "Unlock Ness", WIDGET_CVAR_CHECKBOX).CVar("gCheats.UnlockNess").RaceDisable(false);
+
+    AddWidget(path, "Individual Features", WIDGET_SEPARATOR_TEXT);
+    AddWidget(path, "Unlock Mushroom Kingdom", WIDGET_CVAR_CHECKBOX).CVar("gCheats.UnlockInishie").RaceDisable(false);
+    AddWidget(path, "Unlock Item Switch Menu", WIDGET_CVAR_CHECKBOX).CVar("gCheats.UnlockItemSwitch").RaceDisable(false);
+    AddWidget(path, "Unlock Sound Test Menu", WIDGET_CVAR_CHECKBOX).CVar("gCheats.UnlockSoundTest").RaceDisable(false);
 }
 
 void PortMenu::AddMenuWindows() {


### PR DESCRIPTION
<img width="1604" height="951" alt="Screenshot_20260503_142723" src="https://github.com/user-attachments/assets/d448a1cb-01f4-47eb-aff8-160ade45ca97" />
Adds a Cheats tab in the menu where the user can either unlock everything at once with a single checkbox, or unlock individual components. As alluded to by #98, this eliminates the hassle for grinding so the user can quickly test any particular character or feature out.<br><br>

I should note though that un-checking the box will *not* lock that character or feature back up. The only way to undo any unlock is by deleting the game save data.

@TechnicallyComputers mentioned in the Discord though that we'll somehow need to disable these cheats during netplay sessions.