### PR TITLE
package-windows.ps1: drop NON_PORTABLE — ship as portable zip

### DIFF
--- a/scripts/package-windows.ps1
+++ b/scripts/package-windows.ps1
@@ -13,10 +13,22 @@
 #     SDL2.dll                   — runtime dependency (vcpkg-bundled)
 #     <other vcpkg DLLs>         — picked up by Get-ChildItem from build dir
 #
-# Built with NON_PORTABLE=ON so saves and config land in
-# %APPDATA%\BattleShip\ instead of next to the .exe — same as macOS bundle.
-# BattleShip.o2r is NOT bundled; the first-run wizard extracts it from the
-# user's ROM into %APPDATA%\BattleShip\BattleShip.o2r.
+# Portable: drop the extracted folder anywhere and run BattleShip.exe.
+# Save data and config (ssb64_save.bin, BattleShip.cfg.json, logs/) land
+# next to the .exe in the extraction directory — move the folder, the
+# saves move with it. BattleShip.o2r is NOT bundled; the first-run wizard
+# extracts it from the user's ROM into the same directory as BattleShip.exe.
+#
+# We intentionally do NOT pass -DNON_PORTABLE=ON. NON_PORTABLE bakes
+# CMAKE_INSTALL_PREFIX into libultraship's install_config.h at configure
+# time, and CMake resolves any relative prefix against the configure cwd —
+# so on the GitHub Actions runner that bakes the runner workspace path
+# (e.g. "D:/a/BattleShip/BattleShip/BattleShip"), which v0.7.2 shipped
+# and which crashed user machines whose D: drive returned ERROR_NOT_READY
+# when libultraship probed it. Building portable side-steps the entire
+# class of bug: the runtime resolves resource paths via GetModuleFileNameW
+# (LUS Context::GetAppBundlePath, _WIN32 branch) and saves via the same
+# mechanism, so the only paths the binary ever touches are exe-relative.
 
 $ErrorActionPreference = "Stop"
 
@@ -48,20 +60,15 @@ foreach ($f in @("info.credits.us.txt", "companies.credits.us.txt")) {
 }
 Pop-Location
 
-# ── 1. Configure + build with NON_PORTABLE=ON (Release) ──
-Write-Step "Configuring release build with NON_PORTABLE=ON"
-# CMAKE_INSTALL_PREFIX is baked into libultraship's install_config.h at
-# configure time and returned by Ship::Context::GetAppBundlePath() under
-# NON_PORTABLE. CMake's Windows default is $ENV{ProgramFiles(x86)}/<project>
-# (e.g. "C:\Program Files (x86)\ssb64") which is meaningless for a zip the
-# user extracts to an arbitrary directory. We never run `cmake --install`,
-# so the value is cosmetic — the runtime path resolution lives in
-# port/app_paths.cpp::RealAppBundlePath() (GetModuleFileNameW). Set a
-# readable label so log lines make sense.
+# ── 1. Configure + build (Release, portable) ──
+Write-Step "Configuring release build (portable)"
+# No NON_PORTABLE, no CMAKE_INSTALL_PREFIX. LUS resolves the bundle path
+# via GetModuleFileNameW at runtime, and the port's port_save.cpp +
+# Ship::Context::GetAppDirectoryPath() route saves/config to the cwd
+# (= BattleShip.exe's directory when launched normally). See the file
+# header for the v0.7.2 crash this avoids.
 cmake -B $BuildDir $Root `
     -DCMAKE_BUILD_TYPE=Release `
-    -DNON_PORTABLE=ON `
-    -DCMAKE_INSTALL_PREFIX=BattleShip `
     | Out-Null
 if ($LASTEXITCODE -ne 0) { Fail "cmake configure failed" }
 
@@ -144,5 +151,5 @@ if (-not (Test-Path $ZipPath)) { Fail "zip was not created" }
 
 $ZipKB = [int]((Get-Item $ZipPath).Length / 1024)
 Write-Host "`n✓ Release zip ready: $ZipPath ($ZipKB KB)" -ForegroundColor Green
-Write-Host "   App-data: %APPDATA%\BattleShip\"
+Write-Host "   Portable: extract anywhere; save data lives next to BattleShip.exe."
 Write-Host "   First launch will prompt for your ROM via the ImGui wizard."


### PR DESCRIPTION
## Summary

- **Windows release zip is now genuinely portable.** Extract the folder anywhere, run `BattleShip.exe`, and save data + config + per-game logs land next to the .exe in the extraction directory. Move the folder, the saves move with it.
- Drops `-DNON_PORTABLE=ON -DCMAKE_INSTALL_PREFIX=BattleShip` from `scripts/package-windows.ps1`.
- Companion to #123 — that PR makes the symptom of CI install-prefix baking non-fatal (noexcept `exists` in libultraship); this PR removes the cause. Either alone would have prevented the v0.7.2 crash; together they're defense-in-depth.
- **Linux AppImage and macOS .dmg unchanged.** Both already deliver a portable user experience and don't have the install-prefix baking issue.

## Why

`scripts/package-windows.ps1` invoked:

```
cmake -DNON_PORTABLE=ON -DCMAKE_INSTALL_PREFIX=BattleShip
```

from the runner checkout root. CMake resolves a relative `CMAKE_INSTALL_PREFIX` against the configure cwd, so on the GitHub Actions runner that became `D:/a/BattleShip/BattleShip/BattleShip` and got baked into `libultraship/include/ship/install_config.h`. The v0.7.2 binary then probed that path at runtime — for `gamecontrollerdb.txt` via `osContInit` → `LocateFileAcrossAppDirs` — and on user machines whose `D:` drive returned `ERROR_NOT_READY`, the throwing `std::filesystem::exists` rethrew as `filesystem_error`, terminating the controller-init thread.

We never run `cmake --install` in the release flow either, so the install-prefix value was never anything but a foot-gun.

After this change the runtime resolves resource paths via `GetModuleFileNameW` (LUS `Context::GetAppBundlePath`, `_WIN32` branch without `NON_PORTABLE`) and saves via the same mechanism through `Ship::Context::GetAppDirectoryPath()` / `port/port_save.cpp`. No path is baked into the binary; no probe ever targets a runner workspace.

## Save-data migration

v0.7.x users had save data in `%APPDATA%\BattleShip\`. Post-change:

- New saves live next to `BattleShip.exe` in the extraction directory.
- To carry an existing save forward, copy `%APPDATA%\BattleShip\ssb64_save.bin` and `BattleShip.cfg.json` into the new extraction directory before first launch.

Note: `%APPDATA%\BattleShip\ssb64.log` continues to be written there (anchored in `port/port.cpp::main` to `SDL_GetPrefPath` for crash-handler predictability — the log file is intentionally not portable, only user data is).

## Test plan

- [x] Build runs cleanly: `pwsh -NoProfile scripts\package-windows.ps1` → `dist\BattleShip-windows.zip` (4.5 MB).
- [x] `install_config.h` no longer has the runner workspace path baked. Confirmed — generated content:
  ```
  #define CMAKE_INSTALL_PREFIX "C:/Program Files (x86)/ssb64"
  /* #undef NON_PORTABLE */
  ```
  The `CMAKE_INSTALL_PREFIX` macro is still emitted (CMake default), but the runtime never reads it without `NON_PORTABLE` defined.
- [x] Extract zip to a fresh directory (`dist\test-extract\`), copy in `BattleShip.o2r` + `ssb64.o2r`, launch with `SSB64_MAX_FRAMES=120` — runs to frame 120 in 2.03s with exit code 0.
- [x] After test run, `ssb64_save.bin` (3036 B) and `BattleShip.cfg.json` (12580 B) created **in the extraction directory**, not in `%APPDATA%`.
- [x] `logs\BattleShip.log` (LUS spdlog rotating sink) created next to the exe.
- [ ] (CI) Push a tag and verify `BattleShip-windows.zip` artifact still uploads correctly via `.github/workflows/release.yml`.

## What this doesn't change

- **Linux AppImage**: still built with `NON_PORTABLE=ON`. AppImage runtime is read-only — saves go to `\$XDG_DATA_HOME/BattleShip/` (a stable, writable user dir). AppImage is portable from the user's perspective; saves carry across AppImage version bumps. No install-prefix baking issue (AppImage doesn't probe a runner workspace path).
- **macOS .dmg**: still built with `NON_PORTABLE=ON`. macOS `NSBundle::resourcePath` always wins regardless of `NON_PORTABLE` (see the `__APPLE__` branch in `Ship::Context::GetAppBundlePath`). DMG is portable from the user's perspective (drag .app anywhere).

## Class-of-bug

CI bakes the runner workspace path into a release artifact. Same family applies to any `NON_PORTABLE` packaging script. Future audit: check `scripts/package-linux.sh` for similar exposure (currently safe — Linux passes no `CMAKE_INSTALL_PREFIX`, so the default `/usr/local` is baked but never read because the AppImage's actual resource resolution happens via the linuxdeploy-managed AppDir layout).

🤖 Generated with [Claude Code](https://claude.com/claude-code)