### PR TITLE
cmake: pick correct torch.exe path on single-config Ninja builds

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -79,7 +79,14 @@ ExternalProject_Add(TorchExternal
 
 ExternalProject_Get_Property(TorchExternal install_dir)
 if (CMAKE_SYSTEM_NAME STREQUAL "Windows")
-    set(TORCH_EXECUTABLE ${install_dir}/src/TorchExternal-build/$<CONFIGURATION>/torch.exe)
+    # Multi-config generators (Visual Studio, Xcode) put torch.exe under a
+    # per-config subdir; single-config generators (Ninja, Makefiles) put it at
+    # the build root. CMAKE_CONFIGURATION_TYPES is only set on multi-config.
+    if (CMAKE_CONFIGURATION_TYPES)
+        set(TORCH_EXECUTABLE ${install_dir}/src/TorchExternal-build/$<CONFIG>/torch.exe)
+    else()
+        set(TORCH_EXECUTABLE ${install_dir}/src/TorchExternal-build/torch.exe)
+    endif()
     set(TORCH_SIDECAR_NAME torch.exe)
 else()
     set(TORCH_EXECUTABLE ${install_dir}/src/TorchExternal-build/torch)


### PR DESCRIPTION
## Summary

`CMakeLists.txt:82` always included a `$<CONFIGURATION>` subdir (e.g. `Debug/torch.exe`) in the Windows `TORCH_EXECUTABLE` path. That layout is correct for multi-config generators (Visual Studio, Xcode) but wrong for single-config generators (Ninja, Makefiles), which put `torch.exe` at the build root with no config subdir. The mismatch caused the `ssb64` target's post-link copy step to fail with `Error copying file (if different) ... torch.exe: No such file or directory` on every Ninja+Debug build — exit code 1 even though `BattleShip.exe` linked successfully.

## Fix

Branch on `CMAKE_CONFIGURATION_TYPES` (set only on multi-config generators) to pick the right path layout. Also switch from the deprecated `$<CONFIGURATION>` alias to `$<CONFIG>` while we're here.

```cmake
if (CMAKE_CONFIGURATION_TYPES)
    set(TORCH_EXECUTABLE ${install_dir}/src/TorchExternal-build/$<CONFIG>/torch.exe)
else()
    set(TORCH_EXECUTABLE ${install_dir}/src/TorchExternal-build/torch.exe)
endif()
```

## Test plan

- [x] Clean Ninja+Debug from-scratch build of `ssb64` in a fresh worktree on Windows: 689/689 ninja steps, exit 0; `torch.exe` and `BattleShip.exe` both end up in `build/` alongside `f3d.o2r` and `gamecontrollerdb.txt`.
- [ ] Sanity: VS multi-config generator still resolves correctly (path becomes `Debug/torch.exe` for Debug builds, etc.) — `CMAKE_CONFIGURATION_TYPES` is the documented sentinel for "multi-config generator in use."
- [ ] No effect on Linux/macOS path (the `Windows`-gated branch is the only thing that changed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)