### PR TITLE
CMake: fix torch.exe post-build path for single-config generators

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -79,7 +79,14 @@ ExternalProject_Add(TorchExternal
 
 ExternalProject_Get_Property(TorchExternal install_dir)
 if (CMAKE_SYSTEM_NAME STREQUAL "Windows")
-    set(TORCH_EXECUTABLE ${install_dir}/src/TorchExternal-build/$<CONFIGURATION>/torch.exe)
+    # Torch is built via ExternalProject_Add and inherits the parent generator.
+    # Multi-config generators (Visual Studio) place the binary under <CONFIG>/;
+    # single-config generators (Ninja, NMake) drop it directly in the build dir.
+    if(CMAKE_CONFIGURATION_TYPES)
+        set(TORCH_EXECUTABLE ${install_dir}/src/TorchExternal-build/$<CONFIG>/torch.exe)
+    else()
+        set(TORCH_EXECUTABLE ${install_dir}/src/TorchExternal-build/torch.exe)
+    endif()
     set(TORCH_SIDECAR_NAME torch.exe)
 else()
     set(TORCH_EXECUTABLE ${install_dir}/src/TorchExternal-build/torch)


### PR DESCRIPTION
## Summary

- `$<CONFIGURATION>` always inserts a config subdirectory into the torch.exe post-build copy path. That's correct on multi-config generators (Visual Studio: `TorchExternal-build/Debug/torch.exe`) but wrong on single-config generators (Ninja: `TorchExternal-build/torch.exe`).
- Detect via `CMAKE_CONFIGURATION_TYPES` and only insert `$<CONFIG>` on multi-config. Linux/macOS branch unchanged.
- The previous MSVC build PR (#131) was verified under VS multi-config, which masked this on local Ninja+MSVC setups — the symptom is that `BattleShip.exe` links cleanly but the post-build copy of torch.exe fails with `Error copying file ... TorchExternal-build/Debug/torch.exe: No such file or directory` and the target is reported failed.

## Test plan

- [x] Clean Ninja+MSVC Debug build under VS 2022 Developer Shell produces `BattleShip.exe` (17 MB) and `torch.exe` (8 MB) with no errors.
- [ ] CI's existing Windows job uses VS multi-config generator (per `.github/workflows/release.yml`), so it stays in the multi-config branch — no change in CI behavior expected.
- [ ] Local Ninja builds on macOS / Linux are unaffected (the change is inside `if (CMAKE_SYSTEM_NAME STREQUAL "Windows")`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)