### PR TITLE
Fix fresh-tree CI packaging (broke v0.7.6-beta release workflow)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -473,8 +473,16 @@ if(NOT SSB64_BASEROM)
     set(SSB64_BASEROM "${CMAKE_SOURCE_DIR}/baserom.us.z64")
 endif()
 
-add_custom_target(ExtractAssets
-    DEPENDS TorchExternal PrepareBuildInputs GenerateF3DO2R
+# Declared as add_custom_command(OUTPUT ...) rather than add_custom_target
+# so downstream rules that DEPENDS on ${CMAKE_SOURCE_DIR}/BattleShip.o2r as
+# a file (notably Battle-ShipYard's passthrough_reloc commands) connect to
+# this producer through CMake's file-level dependency graph. Without an
+# explicit OUTPUT declaration Ninja errors with "missing and no known rule
+# to make it". The wrapping custom_target keeps `cmake --build . --target
+# ExtractAssets` working for callers that invoke it directly.
+add_custom_command(
+    OUTPUT ${CMAKE_SOURCE_DIR}/BattleShip.o2r
+    DEPENDS TorchExternal PrepareBuildInputs GenerateF3DO2R ${SSB64_BASEROM}
     COMMAND ${TORCH_EXECUTABLE} o2r ${SSB64_BASEROM} -s ${CMAKE_SOURCE_DIR} -d ${CMAKE_SOURCE_DIR}
     COMMAND ${CMAKE_COMMAND} -E make_directory $<TARGET_FILE_DIR:${PROJECT_NAME}>
     COMMAND ${CMAKE_COMMAND} -E copy_if_different
@@ -482,6 +490,7 @@ add_custom_target(ExtractAssets
         $<TARGET_FILE_DIR:${PROJECT_NAME}>/BattleShip.o2r
     COMMENT "Extracting assets from ${SSB64_BASEROM} into O2R archive"
 )
+add_custom_target(ExtractAssets DEPENDS ${CMAKE_SOURCE_DIR}/BattleShip.o2r)
 
 add_custom_target(GenerateBattleShipO2R
     DEPENDS ExtractAssets
@@ -515,6 +524,11 @@ add_custom_target(GeneratePortO2R
 
 set(RELOCDATA_DECOMP_DIR  "${CMAKE_SOURCE_DIR}/decomp")
 set(RELOCDATA_RELOC_TABLE "${CMAKE_SOURCE_DIR}/port/resource/RelocFileTable.cpp")
+# ExtractAssets writes BattleShip.o2r to ${CMAKE_SOURCE_DIR}; tell the modkit
+# to make BuildBattleShipFromSource depend on it so the source-compile +
+# passthrough commands don't race on a fresh `cmake -B && cmake --build` flow
+# (the failure mode that broke v0.7.6-beta packaging).
+set(RELOCDATA_BATTLESHIP_O2R_TARGET ExtractAssets)
 include(Battle-ShipYard/cmake/RelocData.cmake)
 
 if(RELOCDATA_CC)


### PR DESCRIPTION
## Summary

The v0.7.6-beta release workflow failed for all three platforms with:

```
passthrough_reloc.py: error: argument --battleship-o2r: expected one argument
gmake[2]: *** [CMakeFiles/BuildBattleShipFromSource.dir/build.make:2209: relocdata/reloc_resources/0.relo] Error 2
```

Root cause: on a fresh `cmake -B && cmake --build` (the CI flow — no pre-extracted assets), Battle-ShipYard's \`RELOCDATA_BATTLESHIP_O2R\` configure-time fallback resolved to the empty string. The empty string was then interpolated into every passthrough_reloc.py custom command's argv, and argparse rejected it.

## Changes

**Battle-ShipYard submodule** (bump: `3215ec7` → `c675923`):
- \`RELOCDATA_BATTLESHIP_O2R\` defaults to \`\${CMAKE_SOURCE_DIR}/BattleShip.o2r\` (not empty) when the file isn't present at configure time
- Configure-time \`extract_inc_c.py\` gates on \`EXISTS\` (not \"variable non-empty\") so it correctly skips on a fresh tree
- New \`RELOCDATA_BATTLESHIP_O2R_TARGET\` consumer hook — when set, \`add_dependencies(BuildBattleShipFromSource <target>)\` orders the producer before the source-compile pipeline

**Outer \`CMakeLists.txt\`**:
- \`ExtractAssets\` declared as \`add_custom_command(OUTPUT \${CMAKE_SOURCE_DIR}/BattleShip.o2r ...)\` wrapped by a custom target. The OUTPUT declaration plugs the o2r path into CMake's file-level dependency graph so Ninja knows the producer when passthrough_reloc commands \`DEPENDS\` on the path
- Sets \`RELOCDATA_BATTLESHIP_O2R_TARGET=ExtractAssets\` before including the modkit

## Test plan

- [x] Fresh `cmake -B build_release -DCMAKE_BUILD_TYPE=Release && cmake --build build_release -j 4` from a tree with no pre-existing `BattleShip.o2r` — full from-source build succeeds
- [x] Output: 1870 source-compiled resources + 262 passthrough resources packed into `BattleShip.fromsource.o2r` (2132 entries total)
- [x] `BattleShip` executable links cleanly, ASan symbols absent on Release build
- [ ] Release workflow CI green on all three platforms

🤖 Generated with [Claude Code](https://claude.com/claude-code)