### PR TITLE
Reflect decomp-as-submodule + accurate upstream license/copyright lines

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -34,13 +34,26 @@ It does NOT extend to:
   * Anything owned by Nintendo / HAL Laboratory (game code, data, audio,
     textures, models, trademarks). None of that is included in this
     repository.
-  * The decompiled C source under `src/`, which is derived from the
-    VetriTheRetri/ssb-decomp-re project and is governed by that project's
-    license.
-  * The `libultraship/` submodule, which is licensed independently by its
-    upstream maintainers.
-  * The `torch/` submodule, which is licensed independently by its upstream
-    maintainers.
+  * The decompiled C source under the `decomp/` submodule, which is derived
+    from the VetriTheRetri/ssb-decomp-re project
+    (https://github.com/VetriTheRetri/ssb-decomp-re). At the time of writing,
+    the upstream decompilation does not publish an explicit license; this
+    repository makes no copyright claim over the decompiled source and
+    incorporates it by reference as a submodule. Refer to the upstream
+    project (and its contributors) for any rights, terms, or restrictions
+    governing reuse of the decomp tree.
+  * The `libultraship/` submodule (https://github.com/Kenix3/libultraship),
+    licensed independently by its upstream maintainers under the MIT License:
+      Copyright (c) 2022 kenix3 <kenixwhisperwind@gmail.com>
+    libultraship was originated by the Harbour Masters team for the
+    Ship of Harkinian project and is now maintained at Kenix3/libultraship.
+  * The `torch/` submodule (https://github.com/HarbourMasters/Torch),
+    licensed independently by its upstream maintainers under the MIT License:
+      Copyright (c) 2023 Lywx <admin@undervolt.dev>
+    Torch is maintained by the Harbour Masters team.
+  * The `Battle-ShipYard/` modding-toolkit submodule
+    (https://github.com/JRickey/Battle-ShipYard), licensed independently
+    under the MIT License (see its own `LICENSE`).
   * The font assets bundled under `assets/custom/fonts/`, which are licensed
     under the SIL Open Font License, Version 1.1:
       - Montserrat (Copyright 2011 The Montserrat Project Authors,

--- a/README.md
+++ b/README.md
@@ -270,9 +270,9 @@ PRs are welcome but please don't be offended if responses are slow — this is a
 ## Credits & licensing
 
 - Game code, data, sound, textures, models, and trademarks: **© Nintendo / HAL Laboratory.** Not included in this repository, not redistributed, and not endorsed by them.
-- Decompilation: [VetriTheRetri/ssb-decomp-re](https://github.com/VetriTheRetri/ssb-decomp-re) and its contributors.
-- Runtime framework: [libultraship](https://github.com/Kenix3/libultraship) (Kenix3 and the Harbour Masters team).
-- Asset pipeline: [Torch](https://github.com/HarbourMasters/Torch) (Harbour Masters).
+- Decompilation: [VetriTheRetri/ssb-decomp-re](https://github.com/VetriTheRetri/ssb-decomp-re) and its contributors. Vendored as the `decomp/` submodule. At the time of writing the upstream project does not publish an explicit license; this repository makes no copyright claim over the decompiled source and refers to the upstream project for any rights, terms, or restrictions on reuse.
+- Runtime framework: [libultraship](https://github.com/Kenix3/libultraship) — Copyright (c) 2022 kenix3, MIT-licensed. Originated by the Harbour Masters team (Ship of Harkinian) and now maintained at Kenix3/libultraship. Vendored as the `libultraship/` submodule.
+- Asset pipeline: [Torch](https://github.com/HarbourMasters/Torch) — Copyright (c) 2023 Lywx (Harbour Masters), MIT-licensed. Vendored as the `torch/` submodule.
 - Menu fonts: [Montserrat](https://github.com/JulietaUla/Montserrat) and [Inconsolata](https://github.com/cyrealtype/Inconsolata), both bundled under the [SIL Open Font License 1.1](https://openfontlicense.org). License texts ship alongside the font files in [`assets/custom/fonts/`](assets/custom/fonts/).
 - Reference ports I learned from: [Starship](https://github.com/HarbourMasters/Starship) (SF64), [SpaghettiKart](https://github.com/HarbourMasters/SpaghettiKart) (MK64).
 - Port work: me ([JRickey](https://github.com/JRickey)), with an enormous amount of help, debugging, and feature suggestions from contributors in our Discord server.
@@ -287,7 +287,8 @@ Source code in this repository (everything outside the `decomp/`, `libultraship/
 
 The MIT grant covers only the port-specific code (the `port/` layer, build scripts, tools, docs). It does **not** extend to:
 - Game assets, code, audio, textures, models, or any other content owned by Nintendo / HAL Laboratory — none of which is in this repository.
-- The decompilation in the `decomp/` submodule, which carries its own license from the [VetriTheRetri/ssb-decomp-re](https://github.com/VetriTheRetri/ssb-decomp-re) project.
-- The `libultraship` and `torch` submodules, which carry their own upstream licenses.
+- The decompilation vendored as the `decomp/` submodule, sourced from [VetriTheRetri/ssb-decomp-re](https://github.com/VetriTheRetri/ssb-decomp-re). The upstream project does not currently publish an explicit license; this repository makes no copyright claim over the decompiled source and incorporates it by reference. Defer to the upstream project and its contributors for any rights or restrictions on reuse.
+- The `libultraship` submodule — Copyright (c) 2022 kenix3, MIT-licensed (originated by the Harbour Masters team).
+- The `torch` submodule — Copyright (c) 2023 Lywx (Harbour Masters), MIT-licensed.
 - The `Battle-ShipYard` modkit submodule, which is MIT-licensed under its own [LICENSE](https://github.com/JRickey/Battle-ShipYard/blob/main/LICENSE).
 - The bundled menu fonts under `assets/custom/fonts/`, which are licensed under the SIL Open Font License 1.1 (per-font license files in that directory).

--- a/README.md
+++ b/README.md
@@ -274,7 +274,8 @@ PRs are welcome but please don't be offended if responses are slow — this is a
 - Runtime framework: [libultraship](https://github.com/Kenix3/libultraship) — Copyright (c) 2022 kenix3, MIT-licensed. Originated by the Harbour Masters team (Ship of Harkinian) and now maintained at Kenix3/libultraship. Vendored as the `libultraship/` submodule.
 - Asset pipeline: [Torch](https://github.com/HarbourMasters/Torch) — Copyright (c) 2023 Lywx (Harbour Masters), MIT-licensed. Vendored as the `torch/` submodule.
 - Menu fonts: [Montserrat](https://github.com/JulietaUla/Montserrat) and [Inconsolata](https://github.com/cyrealtype/Inconsolata), both bundled under the [SIL Open Font License 1.1](https://openfontlicense.org). License texts ship alongside the font files in [`assets/custom/fonts/`](assets/custom/fonts/).
-- Reference ports I learned from: [Starship](https://github.com/HarbourMasters/Starship) (SF64), [SpaghettiKart](https://github.com/HarbourMasters/SpaghettiKart) (MK64).
+- Reference ports I learned from and adapted code from: [Starship](https://github.com/HarbourMasters/Starship) (SF64) and [Ship of Harkinian](https://github.com/HarbourMasters/Shipwright) (OoT) — both MIT-licensed by The Harbour Masters; see [`LICENSE`](LICENSE) for the per-file attribution.
+- Reference ports I learned from but did not borrow code from: [SM64 PC Port](https://github.com/sm64-port/sm64-port) (SM64), [SpaghettiKart](https://github.com/HarbourMasters/SpaghettiKart) (MK64).
 - Port work: me ([JRickey](https://github.com/JRickey)), with an enormous amount of help, debugging, and feature suggestions from contributors in our Discord server.
 
 This project is **not affiliated with, endorsed by, or authorized by Nintendo.** It is a personal, non-commercial research and preservation effort. Do not upload ROMs, extracted `.o2r` archives, or any other Nintendo-owned data to issues or pull requests.


### PR DESCRIPTION
LICENSE:
- Fix stale `src/` path: the decomp now lives under the `decomp/`
  submodule, not in-tree.
- Be honest about the decomp upstream license status:
  VetriTheRetri/ssb-decomp-re does not publish an explicit LICENSE at
  the time of writing, so reword from "governed by that project's
  license" (which doesn't exist) to a clear no-claim / defer-to-upstream
  statement.
- Reproduce the actual upstream copyright lines for the libultraship and
  torch submodules (Copyright (c) 2022 kenix3 and Copyright (c) 2023
  Lywx) and note the Harbour Masters origin/maintenance for both.
- Add the Battle-ShipYard modkit submodule to the carve-out list.

README.md (Credits & licensing + License sections):
- Mirror the same submodule + license/copyright clarifications so the
  README and LICENSE agree.