### PR TITLE
Fix C-Stick Smash drift, cross-axis aerials, and CSS palette hijack (#97)

### DIFF
--- a/port/enhancements/enhancements.cpp
+++ b/port/enhancements/enhancements.cpp
@@ -121,30 +121,45 @@ extern "C" void port_enhancement_c_stick_smash(int player_index, unsigned short*
     if (player_index < 0 || player_index >= PORT_ENHANCEMENT_MAX_PLAYERS) return;
     if (!CVarGetInteger(kCStickSmashCVars[player_index], 0)) return;
 
-    if (*button_hold & U_CBUTTON) {
-        *button_hold &= ~U_CBUTTON;
-        *button_tap &= ~U_CBUTTON;
+    // Always strip C-bits from both hold/tap so the engine never sees the raw
+    // C-button input on this player when the remap is on (otherwise the stock
+    // jump assignments would also fire alongside the synthesised attack).
+    const unsigned short cbits = U_CBUTTON | D_CBUTTON | L_CBUTTON | R_CBUTTON;
+    *button_hold &= ~cbits;
+    *button_tap  &= ~cbits;
+
+    // Fire the smash/aerial only on the rising edge of the C-button. A real
+    // C-stick is analog and self-centers; translating it from a digital button
+    // means as long as the C-button is pressed, the engine would otherwise see
+    // stick pinned at ±80 — which manifests as drift in the air / running on
+    // the ground (issue #97 [1]). Holding A across multiple frames also isn't
+    // useful in SSB64 (no smash-attack charging), so a single-frame edge is
+    // enough to register the attack.
+    //
+    // Cross-axis is forced to 0 so the input lands as a pure-axis tilt rather
+    // than a 45° diagonal when the L-stick is already held sideways — without
+    // this, e.g. C-up while running right reads as (80, 80) and the engine's
+    // dominant-axis logic picks fair/bair instead of upair (issue #97 [2]).
+    if (tap_pre_remap & U_CBUTTON) {
+        *stick_x = 0;
         *stick_y = 80;
         *button_hold |= A_BUTTON;
-        if (tap_pre_remap & U_CBUTTON) *button_tap |= A_BUTTON;
-    } else if (*button_hold & D_CBUTTON) {
-        *button_hold &= ~D_CBUTTON;
-        *button_tap &= ~D_CBUTTON;
+        *button_tap  |= A_BUTTON;
+    } else if (tap_pre_remap & D_CBUTTON) {
+        *stick_x = 0;
         *stick_y = -80;
         *button_hold |= A_BUTTON;
-        if (tap_pre_remap & D_CBUTTON) *button_tap |= A_BUTTON;
-    } else if (*button_hold & L_CBUTTON) {
-        *button_hold &= ~L_CBUTTON;
-        *button_tap &= ~L_CBUTTON;
+        *button_tap  |= A_BUTTON;
+    } else if (tap_pre_remap & L_CBUTTON) {
         *stick_x = -80;
+        *stick_y = 0;
         *button_hold |= A_BUTTON;
-        if (tap_pre_remap & L_CBUTTON) *button_tap |= A_BUTTON;
-    } else if (*button_hold & R_CBUTTON) {
-        *button_hold &= ~R_CBUTTON;
-        *button_tap &= ~R_CBUTTON;
+        *button_tap  |= A_BUTTON;
+    } else if (tap_pre_remap & R_CBUTTON) {
         *stick_x = 80;
+        *stick_y = 0;
         *button_hold |= A_BUTTON;
-        if (tap_pre_remap & R_CBUTTON) *button_tap |= A_BUTTON;
+        *button_tap  |= A_BUTTON;
     }
 }
 


### PR DESCRIPTION
Fixes #97. Three independent issues with the C-Stick Smash remap merged in #92:

## [1] Holding C-left/right drifts in air

The remap fired every frame the C-button was **held** and pinned `stick_x` to ±80. A digital button stand-in for an analog C-stick never let the synthetic stick recenter, so the character kept drifting after the smash animation ended.

**Fix:** `port/enhancements/enhancements.cpp` — trigger only on the rising edge (`tap_pre_remap & X_CBUTTON`) and add `A` to both `button_hold` and `button_tap` for that single frame. Strip the C-bits unconditionally so the stock C-button-as-jump can't co-fire.

## [2] C-up/down doesn't fire upair/dair while running

The handler only overrode one axis, so running right + C-up read as `(80, 80)` and the engine's dominant-axis logic picked fair/bair from the 45° diagonal instead of upair.

**Fix:** zero the cross-axis — `stick_x = 0` for C-up/down, `stick_y = 0` for C-L/R — so the input lands as a pure-axis tilt.

## [3] CSS palette cycling broken after Classic / Bonus

`controller.c` gated on `gSCManagerBattleState->players[i].fighter_gobj != NULL`, but `gSCManagerBattleState` is never NULLed at scene exit and the existing #103 defense only scrubs three of the >12 BattleState statics. Returning to CSS from Bonus left the pointer aimed at `sSC1PBonusStageBattleState`, whose `fighter_gobj` slots were stale non-NULL — so the remap fired in CSS and C-buttons moved the cursor instead of cycling palette.

**Fix:** `decomp/src/sys/controller.c` — gate on `gSCManagerSceneData.scene_curr` (whitelist of `VSBattle / 1PGame / 1PBonusStage / 1PTrainingMode`). The scene id is the source of truth and immune to BattleState pointer rot.

## Decomp bump

- `e88fa558b` — `PORT: fix C-Stick Smash gameplay guard against stale BattleState`

## Test plan

- [x] Clean Debug build (688/688 TUs)
- [x] In air, hold C-Right with no L-stick input → no drift
- [x] Run right + C-Up → upair fires (not fair)
- [x] Bonus 1 → exit to menu → enter VS Mode CSS → C-buttons cycle palette as normal

🤖 Generated with [Claude Code](https://claude.com/claude-code)