### PR TITLE
Script/Code mod support with TinyCC

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -23,6 +23,15 @@ if(NOT CMAKE_BUILD_TYPE)
     set(CMAKE_BUILD_TYPE "Debug" CACHE STRING "Choose the type of build." FORCE)
 endif()
 
+# Disable MSVC's vectorized STL helpers (added in 14.40 / VS 17.10).
+# Some VS installs ship the headers without the matching vcruntime
+# symbols, which produces unresolved external errors at link
+# (__std_find_first_of_trivial_pos_1 etc). The fallback non-vectorized
+# variants are functionally equivalent and always work.
+if(MSVC)
+    add_compile_definitions(_USE_STD_VECTOR_ALGORITHMS=0)
+endif()
+
 ################################################################################
 # Options
 ################################################################################
@@ -59,6 +68,23 @@ set(BUILD_SSB64 ON CACHE BOOL "" FORCE)
 ################################################################################
 
 add_subdirectory(libultraship ${CMAKE_BINARY_DIR}/libultraship)
+
+################################################################################
+# MinHook - runtime function-detouring lib used by the mod loader.
+#
+# Mods install hooks on engine functions at runtime; MinHook does the
+# prologue rewrite + trampoline emit. Pulled in via FetchContent so the
+# repo doesn't carry a vendored copy.
+################################################################################
+
+include(FetchContent)
+FetchContent_Declare(
+    minhook
+    GIT_REPOSITORY https://github.com/TsudaKageyu/minhook.git
+    GIT_TAG        master
+    GIT_SHALLOW    TRUE
+)
+FetchContent_MakeAvailable(minhook)
 
 ExternalProject_Add(TorchExternal
     PREFIX TorchExternal
@@ -392,7 +418,44 @@ target_include_directories(${PROJECT_NAME} PRIVATE
 
 add_dependencies(${PROJECT_NAME} libultraship TorchExternal)
 add_dependencies(ssb64_game GenerateCreditsAssets)
-target_link_libraries(${PROJECT_NAME} PRIVATE libultraship)
+target_link_libraries(${PROJECT_NAME} PRIVATE libultraship minhook)
+
+################################################################################
+# Mod-system linkage requirements
+#
+# 1. Disable function inlining on the main executable so engine
+#    functions remain resolvable + hookable by name. Without this, the
+#    optimizer can collapse a hookable function into its caller and
+#    eliminate the address mods would target. /Ob0 (MSVC) and
+#    -fno-inline-functions (GCC/Clang) preserve every function as a
+#    standalone symbol.
+#
+#    Cost: marginal. The decomp is already non-matching for the port
+#    build and the renderer is the perf bottleneck, not game logic.
+#
+# 2. Ensure PDB (Windows) / debug symbols (Linux/macOS) are produced
+#    for Release builds too, since symbol resolution depends on them.
+################################################################################
+
+if (MSVC)
+    target_compile_options(${PROJECT_NAME} PRIVATE /Ob0)
+    target_compile_options(ssb64_game     PRIVATE /Ob0)
+    # /Zi on compile + /DEBUG on link emits a PDB for every config,
+    # not just Debug. Release builds otherwise strip symbols.
+    target_compile_options(${PROJECT_NAME} PRIVATE /Zi)
+    target_compile_options(ssb64_game     PRIVATE /Zi)
+    # NOTE: do NOT add /OPT:REF or /OPT:ICF here. /OPT:REF strips
+    # unreferenced symbols (mods reach in by-name even when nothing
+    # in the binary references the function); /OPT:ICF folds
+    # identical code sections (two functions with the same body
+    # collapse to one symbol, breaking hook-by-name when two ports
+    # of the same function exist). Plain /DEBUG is enough; it just
+    # tells the linker to emit a full PDB.
+    target_link_options(${PROJECT_NAME}    PRIVATE /DEBUG)
+else()
+    target_compile_options(${PROJECT_NAME} PRIVATE -fno-inline-functions -g)
+    target_compile_options(ssb64_game     PRIVATE -fno-inline-functions -g)
+endif()
 
 ################################################################################
 # Platform-specific settings
@@ -407,6 +470,25 @@ if (CMAKE_SYSTEM_NAME STREQUAL "Windows")
     target_sources(${PROJECT_NAME} PRIVATE port/ssb64.rc)
 elseif (CMAKE_SYSTEM_NAME STREQUAL "Linux")
     target_link_options(${PROJECT_NAME} PRIVATE -Wl,-export-dynamic)
+endif()
+
+################################################################################
+# TCC mod scripting: export the engine's full symbol table so libtcc-compiled
+# mods can resolve any engine function by name. On Windows this is what makes
+# `tcc.exe -impdef BattleShip.exe -o BattleShip.def` produce a useful import
+# library; on Unix the linker default-visibility + -Wl,-export-dynamic above
+# handles it.
+################################################################################
+if(NOT DISABLE_SCRIPTING)
+    # ENABLE_EXPORTS makes the EXE produce an import library (.lib) and
+    # surface its symbols to runtime-loaded modules. Without it
+    # WINDOWS_EXPORT_ALL_SYMBOLS only generates a .def file but the linker
+    # doesn't actually emit an export table on the EXE - the .exe ends up
+    # without an .edata section and tcc -impdef returns "no symbols found".
+    set_target_properties(${PROJECT_NAME} PROPERTIES
+        ENABLE_EXPORTS TRUE
+        WINDOWS_EXPORT_ALL_SYMBOLS TRUE
+    )
 endif()
 
 ################################################################################
@@ -455,6 +537,102 @@ add_custom_command(TARGET ${PROJECT_NAME} POST_BUILD
         ${TORCH_EXECUTABLE}
         $<TARGET_FILE_DIR:${PROJECT_NAME}>/${TORCH_SIDECAR_NAME}
 )
+
+################################################################################
+# TCC mod scripting: post-build .tcc/ population + BattleShip.def generation
+#
+# At runtime the engine's ScriptLoader feeds mod source through libtcc with
+# include paths under .tcc/include/ and library paths under .tcc/lib/. We
+# populate both from the FetchContent'd TinyCC source tree so the binary is
+# self-contained; modders don't have to install TinyCC.
+#
+# On Windows we additionally run `tcc.exe -impdef BattleShip.exe -o
+# BattleShip.def` to generate the import library that libtcc links mod
+# objects against. WINDOWS_EXPORT_ALL_SYMBOLS (set above) makes the EXE's
+# export table contain every engine function so the .def covers them all.
+################################################################################
+if(NOT DISABLE_SCRIPTING)
+    if(CMAKE_SYSTEM_NAME STREQUAL "Windows")
+        add_custom_command(TARGET ${PROJECT_NAME} POST_BUILD
+            COMMENT "Copying libtcc headers, libs, and runtime DLL..."
+            COMMAND ${CMAKE_COMMAND} -E make_directory "$<TARGET_FILE_DIR:${PROJECT_NAME}>/.tcc/"
+            COMMAND ${CMAKE_COMMAND} -E make_directory "$<TARGET_FILE_DIR:${PROJECT_NAME}>/.tcc/lib/"
+            COMMAND ${CMAKE_COMMAND} -E make_directory "$<TARGET_FILE_DIR:${PROJECT_NAME}>/.tcc/include/"
+            COMMAND ${CMAKE_COMMAND} -E copy_directory
+                "${CMAKE_BINARY_DIR}/_deps/tinycc-src/include/"
+                "$<TARGET_FILE_DIR:${PROJECT_NAME}>/.tcc/include/"
+            COMMAND ${CMAKE_COMMAND} -E copy_directory
+                "${CMAKE_BINARY_DIR}/_deps/tinycc-src/win32/include/"
+                "$<TARGET_FILE_DIR:${PROJECT_NAME}>/.tcc/include/"
+            # libtcc1.a built by MSVC is COFF format which TCC can't
+            # parse. Use tcc.exe itself to recompile the runtime sources
+            # into a TCC-readable archive. -B points tcc at .tcc/ for
+            # tccdefs.h (auto-included via the command line). This
+            # produces libtcc1.o + dllcrt1.o + dllmain.o in TCC's native
+            # object format, then `tcc -ar rcs` bundles them.
+            COMMAND "$<TARGET_FILE:tcc>"
+                -B "$<TARGET_FILE_DIR:${PROJECT_NAME}>/.tcc"
+                -c "${CMAKE_BINARY_DIR}/_deps/tinycc-src/lib/libtcc1.c"
+                -o "$<TARGET_FILE_DIR:${PROJECT_NAME}>/.tcc/lib/libtcc1.o"
+            COMMAND "$<TARGET_FILE:tcc>"
+                -B "$<TARGET_FILE_DIR:${PROJECT_NAME}>/.tcc"
+                -c "${CMAKE_BINARY_DIR}/_deps/tinycc-src/win32/lib/dllcrt1.c"
+                -o "$<TARGET_FILE_DIR:${PROJECT_NAME}>/.tcc/lib/dllcrt1.o"
+            COMMAND "$<TARGET_FILE:tcc>"
+                -B "$<TARGET_FILE_DIR:${PROJECT_NAME}>/.tcc"
+                -c "${CMAKE_BINARY_DIR}/_deps/tinycc-src/win32/lib/dllmain.c"
+                -o "$<TARGET_FILE_DIR:${PROJECT_NAME}>/.tcc/lib/dllmain.o"
+            COMMAND "$<TARGET_FILE:tcc>" -ar rcs
+                "$<TARGET_FILE_DIR:${PROJECT_NAME}>/.tcc/lib/libtcc1.a"
+                "$<TARGET_FILE_DIR:${PROJECT_NAME}>/.tcc/lib/libtcc1.o"
+                "$<TARGET_FILE_DIR:${PROJECT_NAME}>/.tcc/lib/dllcrt1.o"
+                "$<TARGET_FILE_DIR:${PROJECT_NAME}>/.tcc/lib/dllmain.o"
+            # libtcc is built SHARED -> tcc.dll. The exe imports its symbols,
+            # so it must be loadable at process start. Without this the exe
+            # fails with 0xC0000135 (DLL not found) before main() runs.
+            COMMAND ${CMAKE_COMMAND} -E copy_if_different
+                "$<TARGET_FILE:libtcc>"
+                "$<TARGET_FILE_DIR:${PROJECT_NAME}>/$<TARGET_FILE_NAME:libtcc>"
+            VERBATIM
+        )
+        add_custom_command(TARGET ${PROJECT_NAME} POST_BUILD
+            COMMENT "Generating BattleShip.def via tcc -impdef..."
+            COMMAND "$<TARGET_FILE:tcc>"
+                    -impdef "$<TARGET_FILE:${PROJECT_NAME}>"
+                    -o "$<TARGET_FILE_DIR:${PROJECT_NAME}>/.tcc/lib/BattleShip.def"
+            VERBATIM
+        )
+        add_dependencies(${PROJECT_NAME} tcc)
+    elseif(CMAKE_SYSTEM_NAME STREQUAL "Linux")
+        add_custom_command(TARGET ${PROJECT_NAME} POST_BUILD
+            COMMENT "Copying libtcc headers and libs..."
+            COMMAND ${CMAKE_COMMAND} -E make_directory "$<TARGET_FILE_DIR:${PROJECT_NAME}>/.tcc/"
+            COMMAND ${CMAKE_COMMAND} -E make_directory "$<TARGET_FILE_DIR:${PROJECT_NAME}>/.tcc/lib/"
+            COMMAND ${CMAKE_COMMAND} -E make_directory "$<TARGET_FILE_DIR:${PROJECT_NAME}>/.tcc/include/"
+            COMMAND ${CMAKE_COMMAND} -E copy_directory
+                "${CMAKE_BINARY_DIR}/_deps/tinycc-src/include/"
+                "$<TARGET_FILE_DIR:${PROJECT_NAME}>/.tcc/include/"
+            COMMAND ${CMAKE_COMMAND} -E copy
+                "$<TARGET_FILE:libtcc1>"
+                "$<TARGET_FILE_DIR:${PROJECT_NAME}>/.tcc/lib/libtcc1.a"
+            VERBATIM
+        )
+    elseif(CMAKE_SYSTEM_NAME STREQUAL "Darwin")
+        add_custom_command(TARGET ${PROJECT_NAME} POST_BUILD
+            COMMENT "Copying libtcc headers and libs..."
+            COMMAND ${CMAKE_COMMAND} -E make_directory "$<TARGET_FILE_DIR:${PROJECT_NAME}>/.tcc/"
+            COMMAND ${CMAKE_COMMAND} -E make_directory "$<TARGET_FILE_DIR:${PROJECT_NAME}>/.tcc/lib/"
+            COMMAND ${CMAKE_COMMAND} -E make_directory "$<TARGET_FILE_DIR:${PROJECT_NAME}>/.tcc/include/"
+            COMMAND ${CMAKE_COMMAND} -E copy_directory
+                "${CMAKE_BINARY_DIR}/_deps/tinycc-src/include/"
+                "$<TARGET_FILE_DIR:${PROJECT_NAME}>/.tcc/include/"
+            COMMAND ${CMAKE_COMMAND} -E copy
+                "$<TARGET_FILE:libtcc1>"
+                "$<TARGET_FILE_DIR:${PROJECT_NAME}>/.tcc/lib/libtcc1.a"
+            VERBATIM
+        )
+    endif()
+endif()
 
 ################################################################################
 # Asset extraction targets
@@ -560,3 +738,15 @@ elseif(RELOCDATA_CC)
     message(STATUS "RelocData: baserom absent — BuildBattleShipFromSource skipped "
                    "(release CI / no-rom builds; runtime falls back to Torch-passthrough reloc data)")
 endif()
+
+################################################################################
+# Workspace TCC mods
+#
+# Each mod under workspace/ has its own CMakeLists.txt that bundles the
+# mod's source + assets into output/ and stages a copy under
+# build/<config>/mods/<ModName>/ so the runtime loader picks it up.
+# ModO2R provides the optional ssb64_add_mod_o2r_target helper for
+# packaging into a single .o2r distributable.
+################################################################################
+
+include(ModO2R)

--- a/cmake/ModO2R.cmake
+++ b/cmake/ModO2R.cmake
@@ -1,0 +1,31 @@
+# ssb64_add_mod_o2r_target(MOD_NAME)
+#
+# Adds an opt-in custom target `mod_<MOD_NAME>_o2r` that packs the mod's
+# output/ directory into a single distributable .o2r archive using
+# torch.exe's `pack` subcommand. NOT added to ALL — invoke explicitly:
+#
+#     cmake --build build --target mod_<MOD_NAME>_o2r
+#
+# Output: ${CMAKE_CURRENT_SOURCE_DIR}/output/<MOD_NAME>.o2r
+#
+# Distribute the .o2r by copying it into a player's mods/ folder. The
+# runtime loader (port.cpp:MountModsDir) handles .o2r and folder
+# layouts identically through LUS's ArchiveManager — keep the folder
+# install for fast hot-reload during development, ship the .o2r.
+function(ssb64_add_mod_o2r_target MOD_NAME)
+    if(NOT DEFINED TORCH_EXECUTABLE)
+        message(WARNING "ssb64_add_mod_o2r_target(${MOD_NAME}): TORCH_EXECUTABLE not defined; o2r packaging unavailable")
+        return()
+    endif()
+
+    set(WS_OUTPUT ${CMAKE_CURRENT_SOURCE_DIR}/output)
+    set(WS_O2R    ${WS_OUTPUT}/${MOD_NAME}.o2r)
+
+    add_custom_target(mod_${MOD_NAME}_o2r
+        COMMAND ${CMAKE_COMMAND} -E remove -f ${WS_O2R}
+        COMMAND ${TORCH_EXECUTABLE} pack ${WS_OUTPUT} ${WS_O2R} o2r
+        DEPENDS mod_${MOD_NAME} TorchExternal
+        COMMENT "Packing ${MOD_NAME} into ${WS_O2R}"
+        VERBATIM
+    )
+endfunction()

--- a/port/gameloop.cpp
+++ b/port/gameloop.cpp
@@ -23,8 +23,10 @@
 #include "coroutine.h"
 #include "port.h"
 #include "port_watchdog.h"
+#include "hooks/Events.h"
 
 #include <libultraship/libultraship.h>
+#include <libultraship/bridge/eventsbridge.h>
 #include <fast/Fast3dWindow.h>
 #include <fast/interpreter.h>
 
@@ -532,6 +534,13 @@ void PortPushFrame(void)
 	 * `(OSMesg)INTR_VRETRACE` here. */
 	osSendMesg(&gSYSchedulerTaskMesgQueue, port_make_os_mesg_int(INTR_VRETRACE), OS_MESG_NOBLOCK);
 
+	/* TCC mod hook: GamePreUpdateEvent fires once per frame BEFORE the
+	 * per-frame coroutine resume. Listeners run on the main thread with
+	 * the game in an inert state — safe to read but mutating game data
+	 * from here races with the about-to-start game tick. Use Post for
+	 * mutations that should land "after this frame's logic." */
+	CALL_EVENT(GamePreUpdateEvent);
+
 	/* Resume all service thread coroutines that are waiting for messages.
 	 * This runs multiple rounds to handle cascading messages:
 	 *   Round 1: Scheduler picks up VRETRACE, sends ticks to clients
@@ -539,6 +548,12 @@ void PortPushFrame(void)
 	 *   Round 3+: Display list submitted, scheduler processes GFX task, etc.
 	 * Each thread runs until it yields at osRecvMesg(BLOCK) on empty queue. */
 	port_resume_service_threads();
+
+	/* TCC mod hook: GamePostUpdateEvent fires once per frame AFTER game
+	 * logic + GFX submission. Most common subscription point — game state
+	 * is settled, the display list for this frame has been built, the
+	 * scene tree reflects the just-completed tick. */
+	CALL_EVENT(GamePostUpdateEvent);
 
 	sFrameCount++;
 

--- a/port/gui/PortMenu.cpp
+++ b/port/gui/PortMenu.cpp
@@ -15,6 +15,12 @@
 #include <ship/Context.h>
 #include <ship/window/Window.h>
 #include <ship/window/gui/Gui.h>
+#ifndef DISABLE_SCRIPTING
+#include <ship/scripting/ScriptLoader.h>
+#include "../mods/HookManager.h"
+
+namespace ssb64 { void MountModsDir(); }
+#endif
 
 #include <SDL2/SDL.h>
 #include <spdlog/fmt/fmt.h>
@@ -475,6 +481,62 @@ void PortMenu::AddMenuAssets() {
               WIDGET_TEXT);
 }
 
+#ifndef DISABLE_SCRIPTING
+static void DoHotReload() {
+    auto scripting = Ship::Context::GetInstance()->GetScriptLoader();
+    if (!scripting) {
+        return;
+    }
+    try {
+        /* Unload: ModExit fires, then HookManager uninstalls every
+         * hook owned by that mod (postExit callback runs BEFORE
+         * FreeLibrary so trampolines into the about-to-be-freed mod
+         * code get cleanly removed). Then recompile + reload with the
+         * SetCurrentOwner wrapper so new Install calls re-tag with
+         * the right owner. */
+        scripting->UnloadAll(
+            /*preExit=*/std::nullopt,
+            /*postExit=*/[](const std::string& mod) {
+                ssb64::mods::HookManager::UninstallHooksForOwner(mod.c_str());
+            });
+        /* Pick up any new mod folders/archives that landed in mods/
+         * since the last load. Idempotent: already-mounted archives
+         * are skipped. */
+        ssb64::MountModsDir();
+        scripting->CompileAll();
+        scripting->LoadAll(
+            /*preInit=*/[](const std::string& mod) {
+                ssb64::mods::HookManager::SetCurrentOwner(mod.c_str());
+            },
+            /*postInit=*/[](const std::string&) {
+                ssb64::mods::HookManager::ClearCurrentOwner();
+            });
+    } catch (const std::exception& e) {
+        SPDLOG_ERROR("Mod reload failed: {}", e.what());
+    }
+}
+
+void PortMenu::AddMenuMods() {
+    AddMenuEntry("Mods", CVAR_SETTING("Menu.ModsSidebarSection"));
+
+    WidgetPath path = { "Mods", "Mods", SECTION_COLUMN_1 };
+    AddSidebarEntry("Mods", "Mods", 1);
+    AddWidget(path, "mods_panel", WIDGET_CUSTOM)
+        .CustomFunction([](WidgetInfo&) {
+            if (ImGui::Button("Hot Reload")) {
+                DoHotReload();
+            }
+            if (ImGui::IsItemHovered()) {
+                ImGui::SetTooltip("Unload + recompile + re-init all TCC mods.\n"
+                                  "Adding or removing mod folders still needs an engine restart.");
+            }
+            ImGui::Separator();
+            ImGui::TextWrapped("Mods are loaded from the mods/ folder next to the executable. "
+                               "Drop a folder or .o2r in there, then Hot Reload (or restart) to pick it up.");
+        });
+}
+#endif
+
 void PortMenu::AddMenuAbout() {
     AddMenuEntry("About", CVAR_SETTING("Menu.AboutSidebarSection"));
 
@@ -490,6 +552,9 @@ void PortMenu::AddMenuElements() {
     AddMenuSettings();
     AddMenuWindows();
     AddMenuAssets();
+#ifndef DISABLE_SCRIPTING
+    AddMenuMods();
+#endif
     AddMenuAbout();
 
     if (CVarGetInteger(CVAR_SETTING("Menu.SidebarSearch"), 0)) {

--- a/port/gui/PortMenu.h
+++ b/port/gui/PortMenu.h
@@ -34,6 +34,9 @@ class PortMenu : public Ship::Menu {
     void AddMenuWindows();
     void AddMenuAssets();
     void AddMenuAbout();
+#ifndef DISABLE_SCRIPTING
+    void AddMenuMods();
+#endif
 
   private:
     bool mShowReextractMessage = false;

--- a/port/hooks/Events.cpp
+++ b/port/hooks/Events.cpp
@@ -1,0 +1,25 @@
+/*
+ * Events.cpp — Allocates the storage for BattleShip's event IDs and
+ * registers each event with libultraship's EventSystem at engine init.
+ *
+ * Allocation: this is the ONE translation unit that defines
+ * INIT_EVENT_IDS before #include'ing Events.h. Every other file that
+ * fires or listens for an event sees an extern declaration only.
+ *
+ * Registration: PortRegisterEvents() must be called ONCE after
+ * sContext->InitEventSystem() succeeds. It allocates a runtime EventID
+ * for each declared event so REGISTER_LISTENER / CALL_EVENT can dispatch.
+ */
+#define INIT_EVENT_IDS
+#include "hooks/Events.h"
+
+#include "libultraship/bridge/eventsbridge.h"
+
+extern "C" void PortRegisterEvents(void) {
+    REGISTER_EVENT(GamePreUpdateEvent);
+    REGISTER_EVENT(GamePostUpdateEvent);
+    REGISTER_EVENT(DisplayPreUpdateEvent);
+    REGISTER_EVENT(DisplayPostUpdateEvent);
+    REGISTER_EVENT(EngineRenderMenubarEvent);
+    REGISTER_EVENT(EngineRenderModsEvent);
+}

--- a/port/hooks/Events.h
+++ b/port/hooks/Events.h
@@ -1,0 +1,13 @@
+/*
+ * Events.h — Convenience aggregator for BattleShip-specific engine events.
+ *
+ * Engine-side: include this then CALL_EVENT(GamePostUpdateEvent) at the
+ * appropriate firing point. Mod-side: include this then REGISTER_LISTENER
+ * (GamePostUpdateEvent, EVENT_PRIORITY_NORMAL, OnFrameUpdate).
+ *
+ * Per-category event headers live under list/. Add new categories there;
+ * keep this file thin.
+ */
+#pragma once
+
+#include "list/EngineEvent.h"

--- a/port/hooks/list/EngineEvent.h
+++ b/port/hooks/list/EngineEvent.h
@@ -1,0 +1,41 @@
+/*
+ * EngineEvent.h — Engine-loop and UI events for BattleShip mods.
+ *
+ * These are the events fired from BattleShip's main loop and from the
+ * port's ImGui render. Mods subscribe via REGISTER_LISTENER from
+ * libultraship's bridge/eventsbridge.
+ *
+ * Event firing sites (engine side):
+ *   - GamePreUpdateEvent  — fired in port.cpp before the per-frame game
+ *                           tick (gmMain dispatch).
+ *   - GamePostUpdateEvent — fired in port.cpp after the per-frame game
+ *                           tick. Most common hook for mods that want
+ *                           to read/write game state per frame.
+ *   - DisplayPreUpdateEvent / DisplayPostUpdateEvent — wraps the GFX
+ *                           dispatch (RCP frame submit).
+ *   - EngineRenderMenubarEvent — fired during ImGui menubar render so
+ *                           mods can add their own menu items.
+ *   - EngineRenderModsEvent — fired during ImGui main render so mods
+ *                           can draw their own ImGui windows.
+ *
+ * Convention: REGISTER_EVENT(eventType) is called once at engine init
+ * (port.cpp or PortMenu.cpp) so the EventID is allocated. CALL_EVENT
+ * fires it.
+ */
+#pragma once
+
+/* C-mode mods compile against EventTypes.h directly (DEFINE_EVENT macro,
+ * IEvent/EventID/ListenerID typedefs) without dragging in the C++
+ * EventSystem class. The C-callable bridge symbols REGISTER_LISTENER /
+ * UNREGISTER_LISTENER / CALL_EVENT use are extern "C" in eventsbridge.h. */
+#include "ship/events/EventTypes.h"
+#include "libultraship/bridge/eventsbridge.h"
+
+DEFINE_EVENT(GamePreUpdateEvent);
+DEFINE_EVENT(GamePostUpdateEvent);
+
+DEFINE_EVENT(DisplayPreUpdateEvent);
+DEFINE_EVENT(DisplayPostUpdateEvent);
+
+DEFINE_EVENT(EngineRenderMenubarEvent);
+DEFINE_EVENT(EngineRenderModsEvent);

--- a/port/mods/HookManager.cpp
+++ b/port/mods/HookManager.cpp
@@ -1,0 +1,351 @@
+#include "HookManager.h"
+#include "SymbolResolver.h"
+#include "../port_log.h"
+
+#include <MinHook.h>
+
+#define WIN32_LEAN_AND_MEAN
+#include <windows.h>
+
+#include <algorithm>
+#include <cstring>
+
+namespace ssb64::mods {
+
+std::mutex HookManager::sMutex;
+std::vector<HookManager::HookRecord> HookManager::sHooks;
+std::map<void *, HookManager::ChainState> HookManager::sChains;
+std::string HookManager::sCurrentOwner;
+bool HookManager::sInitialized = false;
+
+/* x86-64 thunk that does an indirect JMP through a pointer slot
+ * stored inline. 14 bytes total:
+ *   FF 25 00 00 00 00     jmp [rip+0]      ; jump to qword at next 8 bytes
+ *   PP PP PP PP PP PP PP PP                ; pointer literal (the call target)
+ *
+ * Updating the thunk's target = overwrite the 8 bytes at offset 6.
+ * Allocated with PAGE_EXECUTE_READWRITE so we can rewrite the slot
+ * without VirtualProtect dance on each update.
+ */
+#define IE_THUNK_SIZE   14
+#define IE_THUNK_PTR_OFF 6
+
+void *HookManager::AllocThunk(void *initial_target)
+{
+    void *mem = VirtualAlloc(nullptr, IE_THUNK_SIZE,
+                             MEM_COMMIT | MEM_RESERVE,
+                             PAGE_EXECUTE_READWRITE);
+    if (mem == nullptr) {
+        return nullptr;
+    }
+    unsigned char *p = (unsigned char *)mem;
+    p[0] = 0xFF; p[1] = 0x25;
+    p[2] = 0x00; p[3] = 0x00; p[4] = 0x00; p[5] = 0x00;
+    std::memcpy(p + IE_THUNK_PTR_OFF, &initial_target, sizeof(void *));
+    return mem;
+}
+
+void HookManager::SetThunkTarget(void *thunk, void *new_target)
+{
+    if (thunk == nullptr) return;
+    unsigned char *p = (unsigned char *)thunk;
+    std::memcpy(p + IE_THUNK_PTR_OFF, &new_target, sizeof(void *));
+}
+
+static const char *MhStatusName(MH_STATUS s)
+{
+    switch (s) {
+    case MH_OK:                     return "MH_OK";
+    case MH_ERROR_ALREADY_INITIALIZED: return "MH_ERROR_ALREADY_INITIALIZED";
+    case MH_ERROR_NOT_INITIALIZED:  return "MH_ERROR_NOT_INITIALIZED";
+    case MH_ERROR_ALREADY_CREATED:  return "MH_ERROR_ALREADY_CREATED";
+    case MH_ERROR_NOT_CREATED:      return "MH_ERROR_NOT_CREATED";
+    case MH_ERROR_ENABLED:          return "MH_ERROR_ENABLED";
+    case MH_ERROR_DISABLED:         return "MH_ERROR_DISABLED";
+    case MH_ERROR_NOT_EXECUTABLE:   return "MH_ERROR_NOT_EXECUTABLE";
+    case MH_ERROR_UNSUPPORTED_FUNCTION: return "MH_ERROR_UNSUPPORTED_FUNCTION";
+    case MH_ERROR_MEMORY_ALLOC:     return "MH_ERROR_MEMORY_ALLOC";
+    case MH_ERROR_MEMORY_PROTECT:   return "MH_ERROR_MEMORY_PROTECT";
+    case MH_ERROR_MODULE_NOT_FOUND: return "MH_ERROR_MODULE_NOT_FOUND";
+    case MH_ERROR_FUNCTION_NOT_FOUND: return "MH_ERROR_FUNCTION_NOT_FOUND";
+    default:                        return "MH_UNKNOWN";
+    }
+}
+
+bool HookManager::Init()
+{
+    std::lock_guard<std::mutex> lock(sMutex);
+    if (sInitialized) {
+        return true;
+    }
+    MH_STATUS s = MH_Initialize();
+    if (s != MH_OK) {
+        port_log("[mods] MH_Initialize failed: %s\n", MhStatusName(s));
+        return false;
+    }
+    sInitialized = true;
+    return true;
+}
+
+void HookManager::Shutdown()
+{
+    std::lock_guard<std::mutex> lock(sMutex);
+    if (!sInitialized) {
+        return;
+    }
+    /* DisableAll + RemoveAll then Uninitialize. MinHook tracks all
+     * installed hooks internally; we don't need to walk sHooks
+     * individually. The vector is just for diagnostic logging. */
+    MH_DisableHook(MH_ALL_HOOKS);
+    MH_Uninitialize();
+    sHooks.clear();
+    sInitialized = false;
+}
+
+int HookManager::InstallHook(const char *symbol_name,
+                             void       *replacement,
+                             void      **original_out)
+{
+    if (original_out != nullptr) {
+        *original_out = nullptr;
+    }
+    if (symbol_name == nullptr || replacement == nullptr) {
+        port_log("[mods] InstallHook: bad args (sym=%p repl=%p)\n",
+                 (const void*)symbol_name, replacement);
+        return 1;
+    }
+
+    std::lock_guard<std::mutex> lock(sMutex);
+    if (!sInitialized) {
+        port_log("[mods] InstallHook(%s): not initialized\n", symbol_name);
+        return 1;
+    }
+
+    void *target = SymbolResolver::Resolve(symbol_name);
+    if (target == nullptr) {
+        port_log("[mods] InstallHook(%s): symbol not found in debug info\n", symbol_name);
+        return 1;
+    }
+
+    auto chain_it = sChains.find(target);
+    if (chain_it == sChains.end()) {
+        /* First hook on this target — standard MinHook setup, plus
+         * an inner_thunk that the first installer will use as its
+         * trampoline (so we can re-route it on subsequent installs). */
+        void *mh_trampoline = nullptr;
+        MH_STATUS s = MH_CreateHook(target, replacement, &mh_trampoline);
+        if (s != MH_OK) {
+            port_log("[mods] InstallHook(%s): MH_CreateHook failed: %s\n",
+                     symbol_name, MhStatusName(s));
+            return 1;
+        }
+        s = MH_EnableHook(target);
+        if (s != MH_OK) {
+            port_log("[mods] InstallHook(%s): MH_EnableHook failed: %s\n",
+                     symbol_name, MhStatusName(s));
+            MH_RemoveHook(target);
+            return 1;
+        }
+        void *inner_thunk = AllocThunk(mh_trampoline);
+        if (inner_thunk == nullptr) {
+            port_log("[mods] InstallHook(%s): inner thunk alloc failed\n", symbol_name);
+            MH_RemoveHook(target);
+            return 1;
+        }
+        ChainState st;
+        st.mh_trampoline = mh_trampoline;
+        st.inner_thunk   = inner_thunk;
+        st.chain.push_back(replacement);
+        st.chain_owners.push_back(sCurrentOwner);
+        st.chain_trampolines.push_back(inner_thunk);
+        sChains[target] = st;
+
+        sHooks.push_back({std::string(symbol_name), target, sCurrentOwner});
+        if (original_out != nullptr) {
+            *original_out = inner_thunk;   /* mod calls this → MinHook trampoline → original */
+        }
+        port_log("[mods] hooked %s @ %p (trampoline=%p, chain=1, owner=%s)\n",
+                 symbol_name, target, inner_thunk,
+                 sCurrentOwner.empty() ? "(unowned)" : sCurrentOwner.c_str());
+        return 0;
+    }
+
+    /* Subsequent hook on a target that's already detoured. Re-create
+     * the MinHook hook so the outer-most replacement is the new mod's
+     * function. The new mod's trampoline points at the previous
+     * outermost replacement (so calling it walks down the chain).
+     * The inner_thunk is updated to the new MinHook trampoline so
+     * the bottom of the chain still reaches the original function. */
+    ChainState &st = chain_it->second;
+    void *prev_outer = st.chain.back();
+
+    MH_STATUS s = MH_RemoveHook(target);
+    if (s != MH_OK) {
+        port_log("[mods] InstallHook(%s): MH_RemoveHook failed: %s\n",
+                 symbol_name, MhStatusName(s));
+        return 1;
+    }
+    void *new_mh_trampoline = nullptr;
+    s = MH_CreateHook(target, replacement, &new_mh_trampoline);
+    if (s != MH_OK) {
+        port_log("[mods] InstallHook(%s): re-create MH_CreateHook failed: %s\n",
+                 symbol_name, MhStatusName(s));
+        sChains.erase(chain_it);
+        return 1;
+    }
+    s = MH_EnableHook(target);
+    if (s != MH_OK) {
+        port_log("[mods] InstallHook(%s): re-enable MH_EnableHook failed: %s\n",
+                 symbol_name, MhStatusName(s));
+        MH_RemoveHook(target);
+        sChains.erase(chain_it);
+        return 1;
+    }
+    /* Reflow the inner thunk to the fresh MinHook trampoline. */
+    SetThunkTarget(st.inner_thunk, new_mh_trampoline);
+    st.mh_trampoline = new_mh_trampoline;
+
+    /* The new mod's trampoline = a thunk that jumps to the previous
+     * outer replacement (which has its own trampoline pointing inward
+     * down the chain). */
+    void *new_trampoline = AllocThunk(prev_outer);
+    if (new_trampoline == nullptr) {
+        port_log("[mods] InstallHook(%s): chain thunk alloc failed\n", symbol_name);
+        return 1;
+    }
+    st.chain.push_back(replacement);
+    st.chain_owners.push_back(sCurrentOwner);
+    st.chain_trampolines.push_back(new_trampoline);
+    sHooks.push_back({std::string(symbol_name), target, sCurrentOwner});
+    if (original_out != nullptr) {
+        *original_out = new_trampoline;
+    }
+    port_log("[mods] chained %s @ %p (trampoline=%p, chain=%zu, owner=%s)\n",
+             symbol_name, target, new_trampoline, st.chain.size(),
+             sCurrentOwner.empty() ? "(unowned)" : sCurrentOwner.c_str());
+    return 0;
+}
+
+void HookManager::SetCurrentOwner(const char *owner_id)
+{
+    std::lock_guard<std::mutex> lock(sMutex);
+    sCurrentOwner = (owner_id != nullptr) ? owner_id : "";
+}
+
+void HookManager::ClearCurrentOwner()
+{
+    std::lock_guard<std::mutex> lock(sMutex);
+    sCurrentOwner.clear();
+}
+
+int HookManager::UninstallHooksForOwner(const char *owner_id)
+{
+    if (owner_id == nullptr) {
+        return 0;
+    }
+    std::lock_guard<std::mutex> lock(sMutex);
+    if (!sInitialized) {
+        return 0;
+    }
+    std::string oid(owner_id);
+    int removed = 0;
+
+    /* Walk every chain top-down, removing all entries owned by oid.
+     * Three cases per entry:
+     *   - is top + chain.size==1: remove last entry, MH_RemoveHook,
+     *     free inner_thunk, the chain disappears.
+     *   - is top + chain.size>1:  re-point MinHook at chain[i-1].
+     *   - is mid-chain:           re-point chain[i+1]'s trampoline
+     *     thunk to skip past us. If we're the bottom (i==0), the
+     *     entry above us inherits inner_thunk's role. */
+    for (auto chain_it = sChains.begin(); chain_it != sChains.end();) {
+        ChainState &st = chain_it->second;
+
+        /* Iterate top-down. After each removal vector indices shift,
+         * so we restart the inner walk. Cheap — chains stay short. */
+        bool any_removed = true;
+        while (any_removed) {
+            any_removed = false;
+            for (int i = (int)st.chain.size() - 1; i >= 0; --i) {
+                if (st.chain_owners[i] != oid) {
+                    continue;
+                }
+                void *removed_tramp = st.chain_trampolines[i];
+                bool is_top    = (i == (int)st.chain.size() - 1);
+                bool is_bottom = (i == 0);
+
+                if (is_top && st.chain.size() == 1) {
+                    MH_RemoveHook(chain_it->first);
+                    if (st.inner_thunk != nullptr) {
+                        VirtualFree(st.inner_thunk, 0, MEM_RELEASE);
+                        st.inner_thunk = nullptr;
+                    }
+                } else if (is_top) {
+                    void *new_top = st.chain[i - 1];
+                    MH_RemoveHook(chain_it->first);
+                    void *new_mh_tramp = nullptr;
+                    MH_STATUS s = MH_CreateHook(chain_it->first, new_top, &new_mh_tramp);
+                    if (s == MH_OK) {
+                        MH_EnableHook(chain_it->first);
+                        SetThunkTarget(st.inner_thunk, new_mh_tramp);
+                        st.mh_trampoline = new_mh_tramp;
+                    } else {
+                        port_log("[mods] uninstall %p (owner=%s): MH_CreateHook failed (%d) — chain broken\n",
+                                 chain_it->first, oid.c_str(), (int)s);
+                    }
+                    if (removed_tramp != st.inner_thunk && removed_tramp != nullptr) {
+                        VirtualFree(removed_tramp, 0, MEM_RELEASE);
+                    }
+                } else {
+                    /* Mid-chain: re-point chain[i+1]'s trampoline thunk
+                     * to skip our entry. If we're the bottom, the
+                     * upstairs thunk now points at mh_trampoline (the
+                     * MinHook trampoline that runs original engine
+                     * code) and itself becomes the new inner_thunk. */
+                    void *new_target = is_bottom ? st.mh_trampoline : st.chain[i - 1];
+                    SetThunkTarget(st.chain_trampolines[i + 1], new_target);
+
+                    if (is_bottom) {
+                        if (st.inner_thunk != nullptr) {
+                            VirtualFree(st.inner_thunk, 0, MEM_RELEASE);
+                        }
+                        st.inner_thunk = st.chain_trampolines[i + 1];
+                    } else {
+                        if (removed_tramp != st.inner_thunk && removed_tramp != nullptr) {
+                            VirtualFree(removed_tramp, 0, MEM_RELEASE);
+                        }
+                    }
+                }
+
+                st.chain.erase(st.chain.begin() + i);
+                st.chain_owners.erase(st.chain_owners.begin() + i);
+                st.chain_trampolines.erase(st.chain_trampolines.begin() + i);
+
+                port_log("[mods] uninstalled %p[%d] (owner=%s, %s, chain=%zu)\n",
+                         chain_it->first, i, oid.c_str(),
+                         is_top ? (st.chain.empty() ? "chain emptied" : "was top")
+                                : (is_bottom ? "was bottom (mid-chain skip)" : "mid-chain"),
+                         st.chain.size());
+                removed++;
+                any_removed = true;
+                break; /* restart after vector mutation */
+            }
+        }
+
+        if (st.chain.empty()) {
+            chain_it = sChains.erase(chain_it);
+        } else {
+            ++chain_it;
+        }
+    }
+
+    /* Sweep the diagnostic sHooks list. */
+    sHooks.erase(
+        std::remove_if(sHooks.begin(), sHooks.end(),
+            [&oid](const HookRecord &h) { return h.owner_id == oid; }),
+        sHooks.end());
+
+    return removed;
+}
+
+} // namespace ssb64::mods

--- a/port/mods/HookManager.h
+++ b/port/mods/HookManager.h
@@ -1,0 +1,109 @@
+/**
+ * HookManager.h — Runtime function detouring for mods.
+ *
+ * Wraps MinHook (Windows) behind a clean interface. Each call to
+ * InstallHook resolves the symbol via SymbolResolver, registers a
+ * MinHook detour with the resolved address as the target, enables it,
+ * and writes the trampoline pointer to *original_out so the mod can
+ * delegate to the original function.
+ *
+ * Per-mod ownership: each install records the current owner (set via
+ * SetCurrentOwner before MOD_INIT runs). UninstallHooksForOwner walks
+ * those records and tears them down. Three removal cases are handled:
+ *   - top of chain, chain.size == 1 → MH_RemoveHook, free inner_thunk
+ *   - top of chain, chain.size  > 1 → re-point MinHook at chain[i-1]
+ *   - mid-chain                     → re-stitch chain[i+1]'s trampoline
+ *                                      thunk to skip past us
+ *
+ * Mid-chain re-stitch means a single mod can be hot-reloaded even
+ * when another mod is stacked on top of one of its hooks — the
+ * upper mod stays installed and its calls to "original" now bypass
+ * the removed mod's replacement and reach the engine code directly.
+ *
+ * On engine shutdown, Shutdown() disables and uninstalls all hooks
+ * at once regardless of owner.
+ */
+#pragma once
+
+#include <vector>
+#include <mutex>
+#include <string>
+#include <map>
+
+namespace ssb64::mods {
+
+class HookManager
+{
+public:
+    /* Initialize MinHook. Must be called once at startup. */
+    static bool Init();
+
+    /* Uninstall all hooks and tear down MinHook. */
+    static void Shutdown();
+
+    /* Resolve `symbol_name` via SymbolResolver, install a detour to
+     * `replacement` at the resolved address, write the trampoline
+     * function pointer to *original_out.
+     *
+     * Returns 0 on success. On failure: non-zero, *original_out is
+     * set to nullptr, and the engine logs the cause. */
+    static int InstallHook(const char *symbol_name,
+                           void       *replacement,
+                           void      **original_out);
+
+    /* Set the current "owner" for InstallHook calls. Each subsequent
+     * install records this as its owner_id until ClearCurrentOwner.
+     * ScriptLoader's LoadAll wraps each ModInit with these calls. */
+    static void SetCurrentOwner(const char *owner_id);
+    static void ClearCurrentOwner();
+
+    /* Walk every installed hook owned by `owner_id`, remove from
+     * MinHook, free trampoline thunks, sweep sHooks. Returns the
+     * number of hooks removed. Mid-chain entries (where another
+     * mod's hook is on top) are left in place and a warning is
+     * logged — hot-reload of just that one mod isn't safe; the
+     * normal UnloadAll-then-LoadAll cycle removes top-to-bottom and
+     * never trips this. Safe to call BEFORE FreeLibrary'ing the
+     * owner's DLL. */
+    static int UninstallHooksForOwner(const char *owner_id);
+
+private:
+    struct HookRecord {
+        std::string symbol_name;
+        void       *target;
+        std::string owner_id;
+    };
+
+    /* Per-symbol chain state for stacking multiple hooks on the same
+     * function. Three parallel vectors track each chain entry:
+     *
+     *   chain[i]              — replacement function pointer
+     *   chain_owners[i]       — owner_id at install time
+     *   chain_trampolines[i]  — the thunk the mod stashed as `original`.
+     *                           For i=0 this == inner_thunk (shared).
+     *                           For i>=1 it's an AllocThunk pointing
+     *                           at chain[i-1] (so chain[i]'s "original
+     *                           fn" walks down the chain). Used during
+     *                           uninstall to free the per-entry thunk. */
+    struct ChainState {
+        void *mh_trampoline;
+        void *inner_thunk;
+        std::vector<void *>       chain;
+        std::vector<std::string>  chain_owners;
+        std::vector<void *>       chain_trampolines;
+    };
+
+    static std::mutex sMutex;
+    static std::vector<HookRecord> sHooks;
+    static std::map<void *, ChainState> sChains;
+    static std::string sCurrentOwner;
+    static bool sInitialized;
+
+    /* Allocate an executable thunk that does `jmp [ptr]` where ptr is
+     * stored inline. Returns the thunk address; the caller updates it
+     * by writing to ThunkPointerSlot(thunk). */
+    static void *AllocThunk(void *initial_target);
+    static void  SetThunkTarget(void *thunk, void *new_target);
+};
+
+} // namespace ssb64::mods

--- a/port/mods/SymbolResolver.cpp
+++ b/port/mods/SymbolResolver.cpp
@@ -1,0 +1,119 @@
+#include "SymbolResolver.h"
+#include "../port_log.h"
+
+#include <cstring>
+
+#ifdef _WIN32
+#  define WIN32_LEAN_AND_MEAN
+#  include <windows.h>
+#  include <dbghelp.h>
+#  pragma comment(lib, "dbghelp.lib")
+#elif defined(__linux__) || defined(__APPLE__)
+#  include <dlfcn.h>
+#endif
+
+namespace ssb64::mods {
+
+std::mutex SymbolResolver::sMutex;
+std::unordered_map<std::string, void*> SymbolResolver::sCache;
+bool SymbolResolver::sInitialized = false;
+
+bool SymbolResolver::Init()
+{
+    std::lock_guard<std::mutex> lock(sMutex);
+    if (sInitialized) {
+        return true;
+    }
+
+#ifdef _WIN32
+    /* port.cpp already calls SymInitialize/SymRefreshModuleList during
+     * crash handler setup, but only on first crash. We need it eagerly
+     * during startup so mods can resolve symbols before any crash.
+     * Calling SymInitialize twice on the same process returns FALSE
+     * with ERROR_INVALID_PARAMETER but leaves the previous handle
+     * valid — safe to ignore that specific failure. */
+    HANDLE proc = GetCurrentProcess();
+    SymSetOptions(SymGetOptions() | SYMOPT_DEFERRED_LOADS | SYMOPT_LOAD_LINES | SYMOPT_UNDNAME);
+    if (!SymInitialize(proc, nullptr, TRUE)) {
+        DWORD err = GetLastError();
+        if (err != ERROR_INVALID_PARAMETER) {
+            port_log("[mods] SymInitialize failed (err=%lu)\n", err);
+            return false;
+        }
+        /* Already initialized — refresh module list to pick up any
+         * DLLs (mods + libultraship) loaded since the prior init. */
+        SymRefreshModuleList(proc);
+    }
+    sInitialized = true;
+    return true;
+#else
+    /* Linux/macOS: use dlsym(RTLD_DEFAULT) for resolution. No init
+     * needed, but flag as initialized for the resolve fast-path. */
+    sInitialized = true;
+    return true;
+#endif
+}
+
+void SymbolResolver::Shutdown()
+{
+    std::lock_guard<std::mutex> lock(sMutex);
+    if (!sInitialized) {
+        return;
+    }
+#ifdef _WIN32
+    SymCleanup(GetCurrentProcess());
+#endif
+    sCache.clear();
+    sInitialized = false;
+}
+
+void *SymbolResolver::Resolve(const char *name)
+{
+    if (name == nullptr || name[0] == '\0') {
+        return nullptr;
+    }
+    std::lock_guard<std::mutex> lock(sMutex);
+    if (!sInitialized) {
+        return nullptr;
+    }
+
+    /* Fast path: cached. */
+    auto it = sCache.find(name);
+    if (it != sCache.end()) {
+        return it->second;
+    }
+
+    void *addr = nullptr;
+
+#ifdef _WIN32
+    /* SYMBOL_INFO has a flexible array at the end for the demangled
+     * name; allocate enough room for MAX_SYM_NAME chars. */
+    constexpr size_t kBufSize = sizeof(SYMBOL_INFO) + MAX_SYM_NAME * sizeof(TCHAR);
+    char buf[kBufSize];
+    SYMBOL_INFO *si = reinterpret_cast<SYMBOL_INFO*>(buf);
+    std::memset(si, 0, kBufSize);
+    si->SizeOfStruct = sizeof(SYMBOL_INFO);
+    si->MaxNameLen   = MAX_SYM_NAME;
+
+    if (SymFromName(GetCurrentProcess(), name, si)) {
+        addr = reinterpret_cast<void*>(static_cast<uintptr_t>(si->Address));
+    } else {
+        /* Some symbols (statics, file-scope) are namespaced in the PDB
+         * by their compilation unit. Try a wildcard lookup as a fallback;
+         * SymEnumSymbols with a `*name` mask matches any container. */
+        DWORD err = GetLastError();
+        if (err != ERROR_MOD_NOT_FOUND) {
+            /* Reserved for future enhancement; for now, just log misses. */
+        }
+    }
+#elif defined(__linux__) || defined(__APPLE__)
+    addr = dlsym(RTLD_DEFAULT, name);
+#endif
+
+    if (addr != nullptr) {
+        sCache.emplace(name, addr);
+    }
+    return addr;
+}
+
+} // namespace ssb64::mods

--- a/port/mods/SymbolResolver.h
+++ b/port/mods/SymbolResolver.h
@@ -1,0 +1,42 @@
+/**
+ * SymbolResolver.h — Resolve names of functions/globals in the host
+ * binary via the embedded PDB (Windows) / DWARF (Linux/macOS).
+ *
+ * Used by HookManager to locate functions to hook, and by mods to
+ * call into engine internals from their handlers.
+ */
+#pragma once
+
+#include <string>
+#include <unordered_map>
+#include <mutex>
+
+namespace ssb64::mods {
+
+class SymbolResolver
+{
+public:
+    /* Initialize debug-info access. On Windows this calls SymInitialize
+     * with the host process and loads the BattleShip.pdb sitting next
+     * to the executable. Safe to call multiple times.
+     *
+     * Returns true on success, false if debug info is unavailable
+     * (e.g. PDB stripped, no DWARF). When false, all subsequent
+     * Resolve() calls return nullptr. */
+    static bool Init();
+
+    /* Tear down debug-info access. Called from PortShutdown. */
+    static void Shutdown();
+
+    /* Resolve a symbol name (function or global) to its address.
+     * Returns nullptr if the symbol is not present in the debug info.
+     * Cached — repeated lookups of the same name are O(1). */
+    static void *Resolve(const char *name);
+
+private:
+    static std::mutex sMutex;
+    static std::unordered_map<std::string, void*> sCache;
+    static bool sInitialized;
+};
+
+} // namespace ssb64::mods

--- a/port/mods/mod_bridge.cpp
+++ b/port/mods/mod_bridge.cpp
@@ -1,0 +1,34 @@
+/*
+ * mod_bridge.cpp - C-callable host-side functions exposed to TCC mods.
+ *
+ * TCC mods call these names directly via TCC's link against
+ * BattleShip.def. They wrap the engine subsystems the mods need from
+ * inside MOD_INIT and at runtime: HookManager for installing detours
+ * and SymbolResolver for looking up engine functions by name.
+ *
+ *     mod_install_hook(name, repl, &orig)
+ *     mod_resolve_symbol(name)
+ *
+ * Cross-mod calls (one mod calling into another) go through
+ * libultraship's ScriptGetFunction, not through this bridge.
+ *
+ * Symbols are dllexport on the host side; mod.h declares them
+ * dllimport for mods. The anchor in port.cpp prevents the linker from
+ * dropping this TU at link time.
+ */
+#if defined(_WIN32)
+#  define MOD_BRIDGE_EXPORT extern "C" __declspec(dllexport)
+#else
+#  define MOD_BRIDGE_EXPORT extern "C" __attribute__((visibility("default")))
+#endif
+
+#include "HookManager.h"
+#include "SymbolResolver.h"
+
+MOD_BRIDGE_EXPORT int mod_install_hook(const char* symbol_name, void* replacement, void** original_out) {
+    return ssb64::mods::HookManager::InstallHook(symbol_name, replacement, original_out);
+}
+
+MOD_BRIDGE_EXPORT void* mod_resolve_symbol(const char* symbol_name) {
+    return ssb64::mods::SymbolResolver::Resolve(symbol_name);
+}

--- a/port/port.cpp
+++ b/port/port.cpp
@@ -65,6 +65,18 @@ extern "C" struct GObj *gGCCommonLinks_Ref(int link_id) {
     return gGCCommonLinks[link_id];
 }
 extern "C" void* sModBridgeAnchorFighterListRef = (void*)&gGCCommonLinks_Ref;
+
+/* Stage geometry: mods that distribute spawn positions across the
+ * active stage (StaryuSquad's followers etc) need map_bound_left /
+ * map_bound_right / map_bound_bottom from the engine's ground data.
+ * Same export hole as gGCCommonLinks -- wrap the pointer. */
+struct MPGroundData;
+extern "C" struct MPGroundData *gMPCollisionGroundData_Ref(void);
+extern "C" struct MPGroundData *gMPCollisionGroundData_Ref(void) {
+    extern struct MPGroundData *gMPCollisionGroundData;
+    return gMPCollisionGroundData;
+}
+extern "C" void* sModBridgeAnchorGroundDataRef = (void*)&gMPCollisionGroundData_Ref;
 #endif
 
 #include <filesystem>

--- a/port/port.cpp
+++ b/port/port.cpp
@@ -13,7 +13,9 @@
 #include <cstdlib>
 #include <cstring>
 #include <exception>
+#include <functional>
 #include <typeinfo>
+#include <unordered_set>
 
 #include "resource/ResourceType.h"
 #include "resource/RelocFileFactory.h"
@@ -26,8 +28,30 @@
 #include "enhancements/enhancements.h"
 #include "first_run.h"
 #include "gui/PortMenu.h"
+#include "mods/HookManager.h"
+#include "mods/SymbolResolver.h"
 #include "renderdoc_trigger.h"
 #include "port_log.h"
+
+#ifndef DISABLE_SCRIPTING
+#include <ship/scripting/ScriptLoader.h>
+#include <libultraship/bridge/scriptingbridge.h>
+#endif
+
+extern "C" void PortRegisterEvents(void);
+
+#ifndef DISABLE_SCRIPTING
+/* Force the linker to pull bridge .obj files into the EXE so their
+ * exported symbols land in the .edata table. Mods call these by name;
+ * nothing in the EXE itself references them, so without an explicit
+ * anchor they get dropped at link time and the post-build tcc -impdef
+ * step doesn't see them. */
+extern "C" int   mod_install_hook(const char* symbol_name, void* replacement, void** original_out);
+extern "C" void* mod_resolve_symbol(const char* symbol_name);
+extern "C" void* sScriptingBridgeAnchor = (void*)&ScriptGetFunction;
+extern "C" void* sModBridgeAnchorHook    = (void*)&mod_install_hook;
+extern "C" void* sModBridgeAnchorResolve = (void*)&mod_resolve_symbol;
+#endif
 
 #include <filesystem>
 #include <system_error>
@@ -87,8 +111,27 @@ static void portResolveSymbol(void* addr, char* out, size_t cap)
 		GetModuleFileNameA(mod, modPath, sizeof(modPath));
 		const char *modName = std::strrchr(modPath, '\\');
 		modName = modName ? modName + 1 : modPath;
-		std::snprintf(out, cap, "%s+0x%llx", modName,
-		             (unsigned long long)((uintptr_t)addr - (uintptr_t)mod));
+
+		// Try SymFromAddr for the function name. The mod loader's
+		// SymbolResolver::Init runs SymInitialize during port startup,
+		// so by the time a crash filter fires, symbols are loaded.
+		// Fall back to module+RVA if the lookup fails.
+		constexpr size_t kBufSize = sizeof(SYMBOL_INFO) + MAX_SYM_NAME * sizeof(TCHAR);
+		char symBuf[kBufSize];
+		SYMBOL_INFO* si = reinterpret_cast<SYMBOL_INFO*>(symBuf);
+		std::memset(si, 0, kBufSize);
+		si->SizeOfStruct = sizeof(SYMBOL_INFO);
+		si->MaxNameLen   = MAX_SYM_NAME;
+		DWORD64 disp = 0;
+		if (SymFromAddr(GetCurrentProcess(), (DWORD64)addr, &disp, si) && si->Name[0] != '\0') {
+			std::snprintf(out, cap, "%s+0x%llx %s+0x%llx",
+				modName,
+				(unsigned long long)((uintptr_t)addr - (uintptr_t)mod),
+				si->Name, (unsigned long long)disp);
+		} else {
+			std::snprintf(out, cap, "%s+0x%llx", modName,
+				(unsigned long long)((uintptr_t)addr - (uintptr_t)mod));
+		}
 	}
 }
 
@@ -302,6 +345,91 @@ static LONG WINAPI portWindowsCrashFilter(EXCEPTION_POINTERS* info)
 #endif
 
 static std::shared_ptr<Ship::Context> sContext;
+
+#ifndef DISABLE_SCRIPTING
+namespace ssb64 {
+
+/* Recursively walk mods/, mounting any folder that contains a
+ * manifest.json or any .o2r/.otr/.zip file as a separate archive
+ * with the LUS ArchiveManager. Folders without a manifest.json are
+ * treated as category dirs and traversed for nested mods.
+ *
+ * This means modders can organize via either layout:
+ *
+ *   mods/MasterBall/manifest.json            ← flat
+ *   mods/items/MasterBall/manifest.json      ← categorical
+ *   mods/pokemon/Celebi/manifest.json        ← categorical
+ *   mods/some_pack.o2r                       ← packaged
+ *
+ * Idempotent: AddArchive is only called for paths not already
+ * present in the manager's archive list. Safe to call repeatedly
+ * (e.g. from the Mods → Reload menu, after a modder dropped a
+ * brand-new mod folder in mods/ while the engine was running). */
+void MountModsDir() {
+	namespace fs = std::filesystem;
+	auto rm = sContext ? sContext->GetResourceManager() : nullptr;
+	if (!rm) return;
+	auto am = rm->GetArchiveManager();
+	if (!am) return;
+
+	const fs::path modsDir(ssb64::RealAppBundlePath() + "/mods");
+	std::error_code ec;
+	if (!fs::exists(modsDir, ec)) {
+		return;
+	}
+
+	/* Build a set of already-mounted archive paths so we don't
+	 * double-mount on a rescan. Path comparison is by exact string;
+	 * the LUS manager keeps the path the caller passed to AddArchive. */
+	auto existing_list = am->GetArchives();
+	std::unordered_set<std::string> existing;
+	if (existing_list) {
+		for (const auto& a : *existing_list) {
+			if (a) existing.insert(a->GetPath());
+		}
+	}
+
+	auto try_mount = [&](const fs::path& p) {
+		const std::string path = p.generic_string();
+		if (existing.contains(path)) {
+			return;
+		}
+		if (am->AddArchive(path)) {
+			port_log("SSB64: mounted mod archive -> %s\n", path.c_str());
+			existing.insert(path);
+		} else {
+			port_log("SSB64: failed to mount mod archive -> %s\n", path.c_str());
+		}
+	};
+
+	std::function<void(const fs::path&)> walk = [&](const fs::path& dir) {
+		std::error_code ec_local;
+		for (const auto& entry : fs::directory_iterator(dir, ec_local)) {
+			const fs::path p = entry.path();
+			if (entry.is_regular_file(ec_local)) {
+				const std::string ext = p.extension().string();
+				if (ext == ".o2r" || ext == ".otr" || ext == ".zip") {
+					try_mount(p);
+				}
+				continue;
+			}
+			if (!entry.is_directory(ec_local)) {
+				continue;
+			}
+			/* A folder containing manifest.json is a mod. Otherwise
+			 * treat it as a category directory and recurse. */
+			if (fs::exists(p / "manifest.json", ec_local)) {
+				try_mount(p);
+			} else {
+				walk(p);
+			}
+		}
+	};
+	walk(modsDir);
+}
+
+} // namespace ssb64
+#endif
 
 // Port-side replacement for Ship::Context::LocateFileAcrossAppDirs.
 //
@@ -610,6 +738,68 @@ static int PortInitImpl(int argc, char* argv[]) {
 		port_log("SSB64: Audio initialized at %d Hz\n", (int)audio.SampleRate);
 	}
 	if (!sContext->InitGfxDebugger()) { port_log("SSB64: InitGfxDebugger failed\n"); return 1; }
+
+	if (!sContext->InitEventSystem()) { port_log("SSB64: InitEventSystem failed\n"); return 1; }
+	port_log("SSB64: EventSystem initialized\n");
+
+	// Allocate runtime EventIDs for every event declared in port/hooks/list/*.
+	// Must happen AFTER InitEventSystem (PortRegisterEvents calls
+	// EventSystemRegisterEvent, which dereferences Context::GetEventSystem()).
+	PortRegisterEvents();
+	port_log("SSB64: Engine events registered\n");
+
+#ifndef DISABLE_SCRIPTING
+	// TCC mod scripting: configure the include paths + library paths under
+	// .tcc/ that the engine populates post-build (see CMakeLists.txt). On
+	// Windows we link mods against BattleShip.def (auto-generated from the
+	// EXE export table); on Unix mods resolve symbols dynamically via the
+	// host process's exported symbols.
+	{
+		std::unordered_map<std::string, std::string> defines = {
+			{ "PORT", "1" },
+			{ "REGION_US", "1" },
+			{ "VERSION_US", "1" },
+			{ "F3DEX_GBI_2", "1" },
+			{ "_LANGUAGE_C", "1" },
+			{ "_USE_MATH_DEFINES", "1" },
+			{ "NON_MATCHING", "1" },
+			{ "NON_EQUIVALENT", "1" },
+			{ "AVOID_UB", "1" },
+		};
+		std::vector<std::string> includePaths = {
+			Ship::Context::GetPathRelativeToAppDirectory(".tcc/include"),
+			Ship::Context::GetPathRelativeToAppDirectory(".tcc/include/tcc"),
+			Ship::Context::GetPathRelativeToAppDirectory(".tcc/include/winapi"),
+			Ship::Context::GetPathRelativeToAppDirectory(".tcc/include/sys"),
+			Ship::Context::GetPathRelativeToAppDirectory(".tcc/include/sec_api"),
+		};
+		std::vector<std::string> libraryPaths = {
+			Ship::Context::GetPathRelativeToAppDirectory(".tcc/lib"),
+		};
+#ifdef _WIN32
+		std::vector<std::string> libraries = { "BattleShip.def" };
+#else
+		std::vector<std::string> libraries = {};
+#endif
+		constexpr int kCodeVersion = 1;
+		/* -mms-bitfields makes TCC pack bitfields the way MSVC does
+		 * (start a new storage unit on type changes, e.g. between
+		 * `ub32 X : 1` and `s32 Y : 2`). The engine is built with MSVC
+		 * and several decomp structs (notably FTStruct ~lines
+		 * 1507-1551) mix `ub32`/`s32`/`u32` bitfield types — without
+		 * this flag, TCC packs them all into a single 32-bit unit
+		 * while MSVC splits them across multiple units, shifting every
+		 * field afterwards (e.g. `attr`, `joints`) and causing mod
+		 * reads to land on adjacent function-pointer fields. */
+		if (!sContext->InitScriptLoader(defines, kCodeVersion, "-g -mms-bitfields",
+		                                includePaths, libraryPaths, libraries)) {
+			port_log("SSB64: InitScriptLoader failed\n");
+			return 1;
+		}
+		port_log("SSB64: ScriptLoader initialized (codeVersion=%d)\n", kCodeVersion);
+	}
+#endif
+
 	// InitFileDropMgr already happened earlier — see the wizard plumbing.
 	port_log("SSB64: All subsystems initialized\n");
 
@@ -630,11 +820,59 @@ static int PortInitImpl(int argc, char* argv[]) {
 		0
 	);
 
-	port_log("SSB64: Resource factories registered — init complete\n");
+	port_log("SSB64: Resource factories registered\n");
+
+	/* Mod runtime: bring up symbol resolution + the hook table so TCC
+	 * mods can install hooks during their MOD_INIT below. Hooks land on
+	 * engine functions in memory; the game coroutine started later via
+	 * PortGameInit() picks them up automatically because the patches
+	 * are in the running .text. */
+	if (!ssb64::mods::SymbolResolver::Init()) {
+		port_log("SSB64: SymbolResolver::Init failed - mods will not load\n");
+	}
+	if (!ssb64::mods::HookManager::Init()) {
+		port_log("SSB64: HookManager::Init failed - mods will not load\n");
+	}
+
+#ifndef DISABLE_SCRIPTING
+	/* Mount mods/ entries (folders, .o2r, .zip) into the LUS
+	 * ArchiveManager so ScriptLoader can iterate them. */
+	ssb64::MountModsDir();
+
+	// TCC scripting: compile + load any .o2r / folder mod under mods/ that
+	// declares a `main` entry in its manifest.json. Each mod's source files
+	// are amalgamated by the ScriptLoader, compiled to a temp DLL via libtcc,
+	// and ModInit is called by name. The pre/post-init callbacks tag every
+	// HookManager::InstallHook call with the current mod name so hot-reload
+	// can selectively uninstall hooks per mod without touching others.
+	if (auto scripting = sContext->GetScriptLoader()) {
+		try {
+			scripting->CompileAll();
+			scripting->LoadAll(
+				/*preInit=*/[](const std::string& mod) {
+					ssb64::mods::HookManager::SetCurrentOwner(mod.c_str());
+				},
+				/*postInit=*/[](const std::string&) {
+					ssb64::mods::HookManager::ClearCurrentOwner();
+				});
+			port_log("SSB64: TCC scripted mods compiled + loaded\n");
+		} catch (const std::exception& e) {
+			port_log("SSB64: TCC ScriptLoader threw — continuing without scripted mods: %s\n", e.what());
+		}
+	}
+#endif
+
+	port_log("SSB64: init complete\n");
 	return 0;
 }
 
 void PortShutdown(void) {
+	// Tear down mod hooks first so no replacement function fires during
+	// engine shutdown (replacement code might call into ssb64_game state
+	// that's about to be torn down).
+	ssb64::mods::HookManager::Shutdown();
+	ssb64::mods::SymbolResolver::Shutdown();
+
 	// Drop audio bridge resource references before Ship::Context goes away.
 	// Otherwise their shared_ptrs survive into __cxa_finalize_ranges and
 	// Ship::IResource::~IResource() lands on a shut-down spdlog.

--- a/port/port.cpp
+++ b/port/port.cpp
@@ -51,6 +51,20 @@ extern "C" void* mod_resolve_symbol(const char* symbol_name);
 extern "C" void* sScriptingBridgeAnchor = (void*)&ScriptGetFunction;
 extern "C" void* sModBridgeAnchorHook    = (void*)&mod_install_hook;
 extern "C" void* sModBridgeAnchorResolve = (void*)&mod_resolve_symbol;
+
+/* MSVC's WINDOWS_EXPORT_ALL_SYMBOLS pass exports global *functions* but
+ * not most non-trivial global *data* objects, so engine globals like
+ * gGCCommonLinks don't make it into BattleShip.def and TCC mods can't
+ * resolve them by name. Wrap the ones mods commonly want behind tiny
+ * accessor functions; functions always export. */
+extern "C" struct GObj;
+extern "C" struct GObj *gGCCommonLinks_Ref(int link_id);
+extern "C" struct GObj *gGCCommonLinks_Ref(int link_id) {
+    extern struct GObj *gGCCommonLinks[];
+    /* No bounds-check: callers pass the engine's own enum constants. */
+    return gGCCommonLinks[link_id];
+}
+extern "C" void* sModBridgeAnchorFighterListRef = (void*)&gGCCommonLinks_Ref;
 #endif
 
 #include <filesystem>

--- a/tools/aifc_to_wav.py
+++ b/tools/aifc_to_wav.py
@@ -1,0 +1,241 @@
+#!/usr/bin/env python3
+"""
+aifc_to_wav.py — Decode N64 VADPCM .aifc files to plain S16 PCM .wav.
+
+The N64 SDK's AIFC variant uses Sony VADPCM compression (codec tag
+'VAPC') stored in IFF/AIFC framing with the predictor codebook in an
+APPL/stoc/VADPCMCODES chunk and audio samples in SSND. ffmpeg cannot
+decode this codec; this tool implements the bruteforcing decoder
+algorithm matching torch/src/factories/naudio/v0/AIFCDecode.cpp
+(itself derived from the standard sm64 / nlibgcn aifc_decode tool).
+
+Output is mono S16 LE PCM at the source's sample rate, written as a
+canonical RIFF/WAV. To turn that into the project's interleaved-stereo
+32 kHz S16 .pcm.inc.c expected by the voice mixer, pipe through
+tools/wav_to_pcm_inc_c.py:
+
+    python tools/aifc_to_wav.py input.aifc /tmp/out.wav
+    python tools/wav_to_pcm_inc_c.py /tmp/out.wav out.pcm.inc.c
+
+Usage:
+    aifc_to_wav.py <input.aifc> <output.wav>
+"""
+
+from __future__ import annotations
+
+import struct
+import sys
+import wave
+from pathlib import Path
+
+
+def parse_extended_float(b: bytes) -> float:
+    """Parse an 80-bit IEEE extended-precision float (sample-rate field
+    in AIFF COMM chunks). Big-endian. Returns Python float."""
+    if len(b) != 10:
+        raise ValueError("extended float must be 10 bytes")
+    sign = (b[0] >> 7) & 1
+    exponent = ((b[0] & 0x7f) << 8) | b[1]
+    mantissa = int.from_bytes(b[2:10], 'big')
+    if exponent == 0 and mantissa == 0:
+        return 0.0
+    if exponent == 0x7fff:
+        return float('inf') if sign == 0 else float('-inf')
+    bias = 16383
+    value = mantissa * (2.0 ** (exponent - bias - 63))
+    return -value if sign else value
+
+
+def clamp_s16(x: int) -> int:
+    if x < -0x8000:
+        return -0x8000
+    if x > 0x7fff:
+        return 0x7fff
+    return x
+
+
+def inner_product(length: int, v1: list[int], v2: list[int]) -> int:
+    """Mirror of AIFCDecode.cpp::inner_product — sum of products,
+    divided by 2^11 with floor-rounding adjustment."""
+    out = 0
+    for i in range(length):
+        out += v1[i] * v2[i]
+    dout = out // (1 << 11) if out >= 0 else -((-out) // (1 << 11))
+    fiout = dout * (1 << 11)
+    if (out - fiout) < 0:
+        dout -= 1
+    return dout
+
+
+def expand_codebook(raw_book: list[list[int]], order: int, npredictors: int) -> list[list[list[int]]]:
+    """raw_book[predictor][order][8] of s16 → coefTable[predictor][8][order+8]."""
+    table: list[list[list[int]]] = []
+    for i in range(npredictors):
+        # Initialize coefTable[i] as 8 rows of (order + 8) zeros.
+        entry: list[list[int]] = [[0] * (order + 8) for _ in range(8)]
+        # Fill from raw_book: raw_book[i][j][k] (s16) → entry[k][j].
+        for j in range(order):
+            for k in range(8):
+                entry[k][j] = raw_book[i][j][k]
+        # Set the order-th column from the diagonal of previous rows.
+        for k in range(1, 8):
+            entry[k][order] = entry[k - 1][order - 1]
+        entry[0][order] = 1 << 11
+        # Triangular extension into columns order+1 .. order+7.
+        for k in range(1, 8):
+            for j in range(0, k):
+                entry[j][k + order] = 0
+            for j in range(k, 8):
+                entry[j][k + order] = entry[j - k][order]
+        table.append(entry)
+    return table
+
+
+def decode_frame(frame: bytes, state: list[int], order: int, coef_table: list[list[list[int]]]) -> None:
+    """Decode one 9-byte VADPCM frame into 16 samples, updating state."""
+    header = frame[0]
+    scale = 1 << (header >> 4)
+    optimalp = header & 0xf
+
+    ix = [0] * 16
+    for i in range(0, 16, 2):
+        c = frame[1 + i // 2]
+        ix[i] = c >> 4
+        ix[i + 1] = c & 0xf
+    for i in range(16):
+        if ix[i] >= 8:
+            ix[i] -= 16
+        ix[i] *= scale
+
+    for j in range(2):
+        in_vec = [0] * 16
+        if j == 0:
+            for i in range(order):
+                in_vec[i] = state[16 - order + i]
+        else:
+            for i in range(order):
+                in_vec[i] = state[8 - order + i]
+        for i in range(8):
+            ind = j * 8 + i
+            in_vec[order + i] = ix[ind]
+            state[ind] = inner_product(order + i, coef_table[optimalp][i], in_vec) + ix[ind]
+
+
+def decode_aifc(path: Path) -> tuple[int, list[int]]:
+    """Returns (sample_rate, [s16 samples])."""
+    data = path.read_bytes()
+    pos = 0
+
+    if data[:4] != b'FORM':
+        raise ValueError(f"not an IFF/AIFC file (bad FORM magic): {path}")
+    form_size = struct.unpack('>I', data[4:8])[0]
+    if data[8:12] != b'AIFC':
+        raise ValueError(f"not AIFC form type: {data[8:12]!r}")
+
+    pos = 12
+    sample_rate = 0
+    num_samples = 0
+    coef_table: list[list[list[int]]] | None = None
+    order = 0
+    sound_pointer = -1
+
+    while pos + 8 <= len(data):
+        ck_id = data[pos:pos + 4]
+        ck_size = struct.unpack('>I', data[pos + 4:pos + 8])[0]
+        ck_size_aligned = (ck_size + 1) & ~1
+        body_start = pos + 8
+
+        if ck_id == b'COMM':
+            num_channels = struct.unpack('>h', data[body_start:body_start + 2])[0]
+            num_frames = struct.unpack('>I', data[body_start + 2:body_start + 6])[0]
+            sample_size = struct.unpack('>h', data[body_start + 6:body_start + 8])[0]
+            sample_rate = int(parse_extended_float(data[body_start + 8:body_start + 18]))
+            ctype = data[body_start + 18:body_start + 22]
+            if ctype != b'VAPC':
+                raise ValueError(f"unsupported codec {ctype!r} (only VAPC / VADPCM supported)")
+            if num_channels != 1:
+                raise ValueError(f"{path}: {num_channels} channels (only mono supported)")
+            if sample_size != 16:
+                raise ValueError(f"{path}: {sample_size}-bit samples (only 16-bit supported)")
+            num_samples = num_frames - (num_frames % 16)
+        elif ck_id == b'APPL':
+            ts = data[body_start:body_start + 4]
+            if ts == b'stoc':
+                name_len = data[body_start + 4]
+                if name_len == 11:
+                    chunk_name = bytes(data[body_start + 5:body_start + 5 + 11]).rstrip(b'\x00')
+                    sub_pos = body_start + 5 + 11
+                    if chunk_name == b'VADPCMCODES':
+                        version = struct.unpack('>h', data[sub_pos:sub_pos + 2])[0]
+                        if version != 1:
+                            raise ValueError(f"unknown VADPCMCODES version {version}")
+                        sub_pos += 2
+                        order = struct.unpack('>h', data[sub_pos:sub_pos + 2])[0]
+                        sub_pos += 2
+                        npredictors = struct.unpack('>h', data[sub_pos:sub_pos + 2])[0]
+                        sub_pos += 2
+                        raw_book: list[list[list[int]]] = []
+                        for _ in range(npredictors):
+                            pred: list[list[int]] = []
+                            for _j in range(order):
+                                row = list(struct.unpack(
+                                    '>8h', data[sub_pos:sub_pos + 16]))
+                                pred.append(row)
+                                sub_pos += 16
+                            raw_book.append(pred)
+                        coef_table = expand_codebook(raw_book, order, npredictors)
+                    # VADPCMLOOPS chunks ignored — one-shot SFX don't loop.
+        elif ck_id == b'SSND':
+            offset = struct.unpack('>I', data[body_start:body_start + 4])[0]
+            block_size = struct.unpack('>I', data[body_start + 4:body_start + 8])[0]
+            assert offset == 0 and block_size == 0
+            sound_pointer = body_start + 8
+
+        pos = body_start + ck_size_aligned
+
+    if coef_table is None:
+        raise ValueError(f"{path}: codebook (VADPCMCODES) missing")
+    if sound_pointer < 0:
+        raise ValueError(f"{path}: SSND chunk missing")
+
+    # Decode all frames.
+    state = [0] * 16
+    samples: list[int] = []
+    cur_pos = 0
+    sp = sound_pointer
+    while cur_pos < num_samples:
+        frame = data[sp:sp + 9]
+        if len(frame) < 9:
+            raise ValueError(f"{path}: truncated SSND data at sample {cur_pos}")
+        decode_frame(frame, state, order, coef_table)
+        for s in state:
+            samples.append(clamp_s16(s))
+        cur_pos += 16
+        sp += 9
+
+    return sample_rate, samples
+
+
+def write_wav(path: Path, sample_rate: int, samples: list[int]) -> None:
+    with wave.open(str(path), 'wb') as wf:
+        wf.setnchannels(1)
+        wf.setsampwidth(2)
+        wf.setframerate(sample_rate)
+        wf.writeframes(b''.join(struct.pack('<h', s) for s in samples))
+
+
+def main(argv: list[str]) -> int:
+    if len(argv) != 3:
+        print("usage: aifc_to_wav.py <input.aifc> <output.wav>", file=sys.stderr)
+        return 2
+    in_path = Path(argv[1])
+    out_path = Path(argv[2])
+    sample_rate, samples = decode_aifc(in_path)
+    write_wav(out_path, sample_rate, samples)
+    print(f"{in_path} -> {out_path}: {len(samples)} samples @ {sample_rate} Hz "
+          f"({len(samples) / sample_rate:.3f}s)")
+    return 0
+
+
+if __name__ == '__main__':
+    sys.exit(main(sys.argv))

--- a/tools/merge_mod.py
+++ b/tools/merge_mod.py
@@ -1,0 +1,595 @@
+import os
+import re
+import argparse
+import struct
+from enum import Enum
+from io import BytesIO
+from typing import Optional, Dict
+
+from PIL import Image
+
+class TextureType(Enum):
+    Error = 0
+    RGBA32bpp = 1
+    RGBA16bpp = 2
+    Palette4bpp = 3
+    Palette8bpp = 4
+    Grayscale4bpp = 5
+    Grayscale8bpp = 6
+    GrayscaleAlpha4bpp = 7
+    GrayscaleAlpha8bpp = 8
+    GrayscaleAlpha16bpp = 9
+
+
+TexturePixelMultipliers: Dict[TextureType, float] = {
+    TextureType.Error: 0.0,
+    TextureType.RGBA32bpp: 4.0,
+    TextureType.RGBA16bpp: 2.0,
+    TextureType.Palette4bpp: 0.5,
+    TextureType.Palette8bpp: 1.0,
+    TextureType.Grayscale4bpp: 0.5,
+    TextureType.Grayscale8bpp: 1.0,
+    TextureType.GrayscaleAlpha4bpp: 0.5,
+    TextureType.GrayscaleAlpha8bpp: 1.0,
+    TextureType.GrayscaleAlpha16bpp: 2.0,
+}
+
+class TextureTypeUtils:
+    @staticmethod
+    def num_to_texture_type(num: int) -> TextureType:
+        mapping = {
+            1: TextureType.RGBA32bpp,
+            2: TextureType.RGBA16bpp,
+            3: TextureType.Palette4bpp,
+            4: TextureType.Palette8bpp,
+            5: TextureType.Grayscale4bpp,
+            6: TextureType.Grayscale8bpp,
+            7: TextureType.GrayscaleAlpha4bpp,
+            8: TextureType.GrayscaleAlpha8bpp,
+            9: TextureType.GrayscaleAlpha16bpp,
+        }
+        if num not in mapping:
+            raise ValueError(f"Unknown texture type number: {num}")
+        return mapping[num]
+
+    @staticmethod
+    def str_to_texture_type(string: str) -> TextureType:
+        mapping = {
+            'RGBA32': TextureType.RGBA32bpp,
+            'RGBA16': TextureType.RGBA16bpp,
+            'TLUT': TextureType.RGBA16bpp,
+            'CI4': TextureType.Palette4bpp,
+            'CI8': TextureType.Palette8bpp,
+            'I4': TextureType.Grayscale4bpp,
+            'I8': TextureType.Grayscale8bpp,
+            'IA4': TextureType.GrayscaleAlpha4bpp,
+            'IA8': TextureType.GrayscaleAlpha8bpp,
+            'IA16': TextureType.GrayscaleAlpha16bpp,
+        }
+        if string not in mapping:
+            raise ValueError(f"Unknown texture type string: {string}")
+        return mapping[string]
+
+    @staticmethod
+    def get_buffer_size(tex_type: TextureType, width: int, height: int) -> int:
+        pixels = width * height
+        if tex_type == TextureType.RGBA32bpp:
+            return pixels * 4
+        elif tex_type in (TextureType.RGBA16bpp, TextureType.GrayscaleAlpha16bpp):
+            return pixels * 2
+        elif tex_type in (TextureType.Palette8bpp, TextureType.Grayscale8bpp, TextureType.GrayscaleAlpha8bpp):
+            return pixels
+        elif tex_type in (TextureType.Palette4bpp, TextureType.Grayscale4bpp, TextureType.GrayscaleAlpha4bpp):
+            return (pixels + 1) // 2
+        return 0
+
+
+class Texture:
+    def __init__(self, width: int, height: int, texture_type: TextureType, tex_data: bytearray = None, tlut: Optional['Texture'] = None):
+        self.width = width
+        self.height = height
+        self.texture_type = texture_type
+        self.tex_data_size = TextureTypeUtils.get_buffer_size(texture_type, width, height)
+        self.tex_data = tex_data if tex_data is not None else bytearray(self.tex_data_size)
+        self.tlut = tlut
+
+    def to_png_bytes(self) -> bytes:
+        return N64Graphics.convert_n64_to_png(self)
+
+
+# --- Main Implementation ---
+
+class N64Graphics:
+
+    @staticmethod
+    def has_alpha(texture: Texture) -> bool:
+        t = texture.texture_type
+        return t in (
+            TextureType.Palette4bpp,
+            TextureType.Palette8bpp,
+            TextureType.RGBA32bpp,
+            TextureType.RGBA16bpp,
+            TextureType.GrayscaleAlpha16bpp,
+            TextureType.GrayscaleAlpha8bpp,
+            TextureType.GrayscaleAlpha4bpp,
+        )
+
+    @staticmethod
+    def pixels_to_png(texture: Texture, data: bytes) -> bytes:
+        img = Image.frombytes("RGBA", (texture.width, texture.height), data)
+        out_buffer = BytesIO()
+        img.save(out_buffer, format="PNG")
+        return out_buffer.getvalue()
+
+    @staticmethod
+    def convert_raw_to_n64(texture: Texture, img: Image.Image) -> None:
+        texture.width = img.width
+        texture.height = img.height
+        texture.tex_data_size = TextureTypeUtils.get_buffer_size(texture.texture_type, texture.width, texture.height)
+        texture.tex_data = bytearray(texture.tex_data_size)
+
+        w, h = texture.width, texture.height
+        tex_data = texture.tex_data
+        tex_type = texture.texture_type
+
+        if tex_type == TextureType.RGBA16bpp:
+            img_rgba = img.convert("RGBA")
+            pixels = img_rgba.load()
+            for y in range(h):
+                for x in range(w):
+                    r, g, b, a = pixels[x, y]
+                    pos = ((y * w) + x) * 2
+                    r5 = r // 8
+                    g5 = g // 8
+                    b5 = b // 8
+                    a_bit = 1 if a != 0 else 0
+
+                    data_val = (r5 << 11) | (g5 << 6) | (b5 << 1) | a_bit
+                    tex_data[pos] = (data_val & 0xFF00) >> 8
+                    tex_data[pos + 1] = data_val & 0x00FF
+
+        elif tex_type == TextureType.RGBA32bpp:
+            img_rgba = img.convert("RGBA")
+            pixels = img_rgba.load()
+            for y in range(h):
+                for x in range(w):
+                    r, g, b, a = pixels[x, y]
+                    pos = ((y * w) + x) * 4
+                    tex_data[pos:pos+4] = [r, g, b, a]
+
+        elif tex_type == TextureType.Palette4bpp:
+            img_p = img.convert("P") if img.mode != "P" else img
+            pixels = img_p.load()
+            for y in range(h):
+                for x in range(0, w, 2):
+                    pos = ((y * w) + x) // 2
+                    idx1 = pixels[x, y]
+                    idx2 = pixels[x + 1, y] if x + 1 < w else 0
+                    tex_data[pos] = ((idx1 & 0x0F) << 4) | (idx2 & 0x0F)
+
+        elif tex_type == TextureType.Palette8bpp:
+            img_p = img.convert("P") if img.mode != "P" else img
+            pixels = img_p.load()
+            for y in range(h):
+                for x in range(w):
+                    pos = (y * w) + x
+                    tex_data[pos] = pixels[x, y] & 0xFF
+
+        elif tex_type == TextureType.Grayscale4bpp:
+            img_l = img.convert("L") if img.mode != "L" else img
+            pixels = img_l.load()
+            for y in range(h):
+                for x in range(0, w, 2):
+                    pos = ((y * w) + x) // 2
+                    r1 = pixels[x, y]
+                    r2 = pixels[x + 1, y] if x + 1 < w else 0
+                    tex_data[pos] = (((r1 // 16) << 4) | (r2 // 16)) & 0xFF
+
+        elif tex_type == TextureType.Grayscale8bpp:
+            img_l = img.convert("L") if img.mode != "L" else img
+            pixels = img_l.load()
+            for y in range(h):
+                for x in range(w):
+                    pos = (y * w) + x
+                    tex_data[pos] = pixels[x, y] & 0xFF
+
+        elif tex_type == TextureType.GrayscaleAlpha4bpp:
+            img_la = img.convert("LA") if img.mode != "LA" else img
+            pixels = img_la.load()
+            for y in range(h):
+                for x in range(0, w, 2):
+                    pos = ((y * w) + x) // 2
+                    l1, a1 = pixels[x, y]
+                    l2, a2 = pixels[x + 1, y] if x + 1 < w else (0, 0)
+                    
+                    alpha_bit1 = 1 if a1 != 0 else 0
+                    alpha_bit2 = 1 if a2 != 0 else 0
+
+                    data_val = ((((l1 // 32) << 1) | alpha_bit1) << 4) | (((l2 // 32) << 1) | alpha_bit2)
+                    tex_data[pos] = data_val & 0xFF
+
+        elif tex_type == TextureType.GrayscaleAlpha8bpp:
+            img_la = img.convert("LA") if img.mode != "LA" else img
+            pixels = img_la.load()
+            for y in range(h):
+                for x in range(w):
+                    pos = (y * w) + x
+                    l, a = pixels[x, y]
+                    tex_data[pos] = (((l // 16) << 4) | (a // 16)) & 0xFF
+
+        elif tex_type == TextureType.GrayscaleAlpha16bpp:
+            img_la = img.convert("LA") if img.mode != "LA" else img
+            pixels = img_la.load()
+            for y in range(h):
+                for x in range(w):
+                    pos = ((y * w) + x) * 2
+                    l, a = pixels[x, y]
+                    tex_data[pos] = l & 0xFF
+                    tex_data[pos + 1] = a & 0xFF
+
+        elif tex_type == TextureType.Error:
+            raise ValueError("Unknown texture type")
+
+    @staticmethod
+    def convert_n64_to_png(texture: Texture) -> Optional[bytes]:
+        w, h = texture.width, texture.height
+        tex_data = texture.tex_data
+        tex_type = texture.texture_type
+        is_palette = tex_type in (TextureType.Palette4bpp, TextureType.Palette8bpp)
+
+        img: Optional[Image.Image] = None
+
+        if tex_type == TextureType.RGBA32bpp:
+            img = Image.frombytes("RGBA", (w, h), bytes(tex_data))
+
+        elif tex_type == TextureType.RGBA16bpp:
+            img = Image.new("RGBA", (w, h))
+            pixels = img.load()
+            for y in range(h):
+                for x in range(w):
+                    pos = ((y * w) + x) * 2
+                    data_val = (tex_data[pos] << 8) | tex_data[pos + 1]
+                    r = ((data_val & 0xF800) >> 11) * 8
+                    g = ((data_val & 0x07C0) >> 6) * 8
+                    b = ((data_val & 0x003E) >> 1) * 8
+                    a = (data_val & 0x01) * 255
+                    pixels[x, y] = (r, g, b, a)
+
+        elif tex_type == TextureType.Palette4bpp:
+            img = Image.new("P", (w, h))
+            pixels = img.load()
+            palette = [0] * (256 * 4) 
+            for y in range(h):
+                for x in range(0, w, 2):
+                    pos = ((y * w) + x) // 2
+                    idx1 = (tex_data[pos] & 0xF0) >> 4
+                    idx2 = tex_data[pos] & 0x0F
+                    
+                    pixels[x, y] = idx1
+                    if x + 1 < w:
+                        pixels[x + 1, y] = idx2
+
+                    palette[idx1*4 : idx1*4+4] = [idx1*16, idx1*16, idx1*16, 255]
+                    palette[idx2*4 : idx2*4+4] = [idx2*16, idx2*16, idx2*16, 255]
+
+        elif tex_type == TextureType.Palette8bpp:
+            img = Image.new("P", (w, h))
+            pixels = img.load()
+            palette = [0] * (256 * 4)
+            for y in range(h):
+                for x in range(w):
+                    pos = (y * w) + x
+                    idx = tex_data[pos]
+                    pixels[x, y] = idx
+                    palette[idx*4 : idx*4+4] = [idx, idx, idx, 255]
+
+        elif tex_type == TextureType.Grayscale4bpp:
+            img = Image.new("L", (w, h))
+            pixels = img.load()
+            for y in range(h):
+                for x in range(0, w, 2):
+                    pos = ((y * w) + x) // 2
+                    g1 = tex_data[pos] & 0xF0
+                    g2 = (tex_data[pos] & 0x0F) << 4
+                    
+                    pixels[x, y] = g1
+                    if x + 1 < w:
+                        pixels[x + 1, y] = g2
+
+        elif tex_type == TextureType.Grayscale8bpp:
+            img = Image.new("L", (w, h))
+            pixels = img.load()
+            for y in range(h):
+                for x in range(w):
+                    pos = (y * w) + x
+                    pixels[x, y] = tex_data[pos]
+
+        elif tex_type == TextureType.GrayscaleAlpha4bpp:
+            img = Image.new("LA", (w, h))
+            pixels = img.load()
+            for y in range(h):
+                for x in range(0, w, 2):
+                    pos = ((y * w) + x) // 2
+                    val = tex_data[pos]
+
+                    d1 = (val & 0xF0) >> 4
+                    g1 = ((d1 & 0x0E) >> 1) * 32
+                    a1 = (d1 & 0x01) * 255
+                    pixels[x, y] = (g1, a1)
+
+                    if x + 1 < w:
+                        d2 = val & 0x0F
+                        g2 = ((d2 & 0x0E) >> 1) * 32
+                        a2 = (d2 & 0x01) * 255
+                        pixels[x + 1, y] = (g2, a2)
+
+        elif tex_type == TextureType.GrayscaleAlpha8bpp:
+            img = Image.new("LA", (w, h))
+            pixels = img.load()
+            for y in range(h):
+                for x in range(w):
+                    pos = (y * w) + x
+                    val = tex_data[pos]
+                    g = val & 0xF0
+                    a = (val & 0x0F) << 4
+                    pixels[x, y] = (g, a)
+
+        elif tex_type == TextureType.GrayscaleAlpha16bpp:
+            img = Image.new("LA", (w, h))
+            pixels = img.load()
+            for y in range(h):
+                for x in range(w):
+                    pos = ((y * w) + x) * 2
+                    g = tex_data[pos]
+                    a = tex_data[pos + 1]
+                    pixels[x, y] = (g, a)
+        else:
+            return None
+
+        if is_palette:
+            if texture.tlut:
+                pal_bytes = texture.tlut.to_png_bytes()
+                pal_img = Image.open(BytesIO(pal_bytes)).convert("RGBA")
+                pal_pixels = pal_img.load()
+                
+                for y in range(pal_img.height):
+                    for x in range(pal_img.width):
+                        index = y * pal_img.width + x
+                        if index >= 256:
+                            continue
+                        r, g, b, a = pal_pixels[x, y]
+                        palette[index*4 : index*4+4] = [r, g, b, a]
+            
+            img.putpalette(bytearray(palette), rawmode='RGBA')
+
+        out_buffer = BytesIO()
+        img.save(out_buffer, format="PNG")
+        return out_buffer.getvalue()
+
+def convert_png_to_n64_texture(png_bytes: bytes, texture_type: TextureType) -> Texture:
+    img = Image.open(BytesIO(png_bytes))
+    texture = Texture(0, 0, texture_type)
+    N64Graphics.convert_raw_to_n64(texture, img)
+    return texture
+
+def write_header(resource_type: int, version: int) -> bytes:
+    endianness = 0x00
+    game_version = 0
+    rom_crc = 0
+    rom_enum = 0
+    magic = 0xDEADBEEFDEADBEEF
+
+    # Struct format characters (assuming Little-Endian '<'):
+    # I = unsigned int (4 bytes)
+    # Q = unsigned long long (8 bytes)
+    #
+    # Order: Endianness(I), Type(I), Version(I), Magic(Q), GameVer(I), CRC(Q), Enum(I)
+    header_data = struct.pack(
+        '<IIIQIQI',
+        endianness,     # [0x00] 4 bytes
+        resource_type,  # [0x04] 4 bytes
+        version,        # [0x08] 4 bytes
+        magic,          # [0x0C] 8 bytes
+        game_version,   # [0x14] 4 bytes
+        rom_crc,        # [0x18] 8 bytes
+        rom_enum        # [0x20] 4 bytes
+    )
+
+    # Pad with null bytes until we reach 0x40 (64 bytes)
+    padding_needed = 0x40 - len(header_data)
+    if padding_needed > 0:
+        header_data += b'\x00' * padding_needed
+
+    return header_data
+
+def preprocess_asset(bytes_data: bytes, filename: str) -> bytes:
+    file = filename.lower()
+
+    if file.lower().endswith('.bin'):
+        return bytes_data
+
+    elif file.endswith('.png'):
+        if 'rgba16' in file:
+            tex_type = TextureType.RGBA16bpp
+        elif 'rgba32' in file:
+            tex_type = TextureType.RGBA32bpp
+        elif 'ci4' in file:
+            tex_type = TextureType.Palette4bpp
+        elif 'ci8' in file:
+            tex_type = TextureType.Palette8bpp
+        else:
+            raise ValueError(f"Unknown texture format in filename: {filename}")
+
+        data = convert_png_to_n64_texture(bytes_data, tex_type)
+
+        texture_type = 1
+        width = data.width
+        height = data.height
+        tex_data_size = len(data.tex_data)
+
+        otr_header = write_header(resource_type=0x4F544558, version=0x0)
+        tex_header = struct.pack(
+            '<IIII',
+            texture_type,   # [0x40] 4 bytes
+            width,          # [0x44] 4 bytes
+            height,         # [0x48] 4 bytes
+            tex_data_size   # [0x58] 4 bytes
+        )
+
+        return otr_header + tex_header + data.tex_data
+    else:
+        raise ValueError(f"Unsupported asset file type for {filename}")
+
+def preprocess_embed(bytes_data: bytes, filename: str) -> bytes:
+    # If you want bytes to be embedded directly into the C file, you can preprocess them here.
+    return bytes_data
+
+def amalgamate(file_path, include_dirs, processed, out_file, assets_dir):
+    abs_path = os.path.abspath(file_path)
+
+    if abs_path in processed:
+        return
+    processed.add(abs_path)
+
+    try:
+        with open(abs_path, 'r', encoding='utf-8') as f:
+            content = f.read()
+
+        # Step 1: Find and process `#asset` blocks ONLY
+        # Replaces `u8 array[] = { #asset ... };` with ALIGN_ASSET macro and extracts .bin
+        asset_block_pattern = re.compile(
+            r'(?:(?:static|const|ALIGNED8|extern)\s+)*u8\s+([a-zA-Z0-9_]+)\s*\[\]\s*=\s*\{\s*#asset\s+([<"])([^>"]+)[>"]\s*\};',
+            re.MULTILINE
+        )
+
+        def repl_asset_block(match):
+            var_name = match.group(1)
+            delimiter = match.group(2)
+            target_name = match.group(3)
+
+            target_path = None
+            search_paths = list(include_dirs)
+            if delimiter == '"':
+                search_paths.insert(0, os.path.dirname(abs_path))
+
+            for path in search_paths:
+                potential_path = os.path.join(path, target_name)
+                if os.path.exists(potential_path):
+                    target_path = potential_path
+                    break
+
+            if target_path:
+                try:
+                    with open(target_path, 'rb') as bin_file:
+                        raw_bytes = bin_file.read()
+
+                    resource_name = target_name
+                    if resource_name.lower().endswith('.png'):
+                        resource_name = resource_name[:-4]
+
+                    # Write the .bin companion file mirroring directory tree
+                    if assets_dir:
+                        companion_path = os.path.join(assets_dir, resource_name)
+                        os.makedirs(os.path.dirname(companion_path), exist_ok=True)
+                        with open(companion_path, 'wb') as cf:
+                            cf.write(preprocess_asset(raw_bytes, target_name))
+
+                    # Return formatted string literal block for C
+                    return f'static const ALIGN_ASSET(2) char {var_name}[] = "__OTR__{resource_name}";'
+
+                except Exception as e:
+                    print(f"Warning: Failed to read asset file {target_path}: {e}")
+                    return f"/* ERROR: Failed to process {target_name} */"
+            else:
+                print(f"Warning: Could not find asset file {target_name} requested from {abs_path}")
+                return f"/* ERROR: Could not find {target_name} */"
+
+        # Apply the #asset replacement over the whole text file
+        content = asset_block_pattern.sub(repl_asset_block, content)
+
+        # Step 2: Process the remaining lines one by one for standard #embeds and #includes
+        for line in content.splitlines(keepends=True):
+            
+            # Look for legacy #embed (leaves the surrounding u8 array intact, just injects hex)
+            embed = re.match(r'^\s*#\s*embed\s+([<"])([^>"]+)[>"]', line)
+            if embed:
+                delimiter = embed.group(1)
+                target_name = embed.group(2)
+                target_path = None
+
+                search_paths = list(include_dirs)
+                if delimiter == '"':
+                    search_paths.insert(0, os.path.dirname(abs_path))
+
+                for path in search_paths:
+                    potential_path = os.path.join(path, target_name)
+                    if os.path.exists(potential_path):
+                        target_path = potential_path
+                        break
+
+                if target_path:
+                    out_file.write(f"/* --- Start Embedded Bytes: {target_name} --- */\n")
+                    try:
+                        with open(target_path, 'rb') as bin_file:
+                            raw_bytes = bin_file.read()
+
+                        raw_bytes = preprocess_embed(raw_bytes, target_name)
+                            
+                        # Write out raw hex array right into the C file
+                        hex_array = [f"0x{b:02x}" for b in raw_bytes]
+                        for i in range(0, len(hex_array), 16):
+                            chunk = hex_array[i:i+16]
+                            out_file.write("    " + ", ".join(chunk) + ",\n")
+                    except Exception as e:
+                        print(f"Warning: Failed to read embedded file {target_path}: {e}")
+                        out_file.write(f"/* ERROR: Failed to read {target_name} */\n")
+                    out_file.write(f"/* --- End Embedded Bytes: {target_name} --- */\n")
+                else:
+                    out_file.write(f"/* ERROR: Could not find {target_name} */\n")
+                continue
+
+            # Standard #include amalgamation
+            include = re.match(r'^\s*#\s*include\s+([<"])([^>"]+)[>"]', line)
+            if include:
+                delimiter = include.group(1)
+                header_name = include.group(2)
+                header_path = None
+                search_paths = list(include_dirs)
+                if delimiter == '"':
+                    search_paths.insert(0, os.path.dirname(abs_path))
+
+                for path in search_paths:
+                    potential_path = os.path.join(path, header_name)
+                    if os.path.exists(potential_path):
+                        header_path = potential_path
+                        break
+
+                if header_path:
+                    out_file.write(f"/* --- Start: {header_name} --- */\n")
+                    amalgamate(header_path, include_dirs, processed, out_file, assets_dir)
+                    out_file.write(f"/* --- End: {header_name} --- */\n")
+                else:
+                    out_file.write(line) 
+            else:
+                out_file.write(line)
+    except Exception as e:
+        print(f"Warning: Could not process {abs_path}: {e}")
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser(description="Generate a Unity Build amalgamation.")
+    parser.add_argument('--out', required=True, help="The single output .c file")
+    parser.add_argument('--assets-dir', default=None, help="Root output directory for companion .bin files")
+    parser.add_argument('--includes', nargs='*', default=[], help="Include directories")
+    parser.add_argument('--srcs', nargs='+', required=True, help="Input .c files")
+
+    args = parser.parse_args()
+
+    global_processed = set()
+
+    with open(args.out, 'w', encoding='utf-8') as out_file:
+        for src_file in args.srcs:
+            out_file.write(f"\n/* ========================================= */\n")
+            out_file.write(f"/* === Start of Source: {os.path.basename(src_file)} === */\n")
+            out_file.write(f"/* ========================================= */\n\n")
+
+            amalgamate(src_file, args.includes, global_processed, out_file, args.assets_dir)

--- a/tools/png_to_ia8_inc_c.py
+++ b/tools/png_to_ia8_inc_c.py
@@ -1,0 +1,96 @@
+#!/usr/bin/env python3
+"""
+png_to_ia8_inc_c.py — convert RGBA PNGs to N64 IA8 raw bytes as a .tex.inc.c file.
+
+IA8 is 8-bit-per-pixel: 4-bit intensity + 4-bit alpha. Suited for monochrome
+sprites with anti-aliased edges (text, glyph atlases, B&W silhouettes).
+
+Output format matches png_to_rgba16_inc_c.py's convention:
+    0xHH, 0xHH, ...    (16 hex bytes per line)
+
+Per-pixel encoding:
+    pixel = (intensity_4bit << 4) | alpha_4bit
+where intensity = (R + G + B) / 3 quantized to 4 bits, and alpha is the
+alpha channel quantized to 4 bits.
+
+Usage:
+    png_to_ia8_inc_c.py <input.png> <output.tex.inc.c>
+    png_to_ia8_inc_c.py --batch <input_dir> <output_dir>
+"""
+
+from __future__ import annotations
+
+import argparse
+import sys
+from pathlib import Path
+
+from PIL import Image
+
+
+def png_to_ia8_bytes(png_path: Path) -> tuple[bytearray, int, int]:
+    """Load an RGBA PNG and return (raw_ia8_bytes, width, height)."""
+    img = Image.open(png_path).convert("RGBA")
+    w, h = img.size
+    px = img.load()
+    raw = bytearray(w * h)
+
+    for y in range(h):
+        for x in range(w):
+            r, g, b, a = px[x, y]
+            i = (r + g + b) // 3
+            i4 = (i >> 4) & 0xF
+            a4 = (a >> 4) & 0xF
+            raw[y * w + x] = (i4 << 4) | a4
+
+    return raw, w, h
+
+
+def write_inc_c(raw: bytes, output_path: Path, width: int, height: int) -> None:
+    output_path.parent.mkdir(parents=True, exist_ok=True)
+    with open(output_path, "w", encoding="utf-8") as f:
+        f.write(f"/* Auto-generated from PNG via png_to_ia8_inc_c.py — do not edit. */\n")
+        f.write(f"/* Format: N64 IA8 ({width}x{height}, {len(raw)} bytes raw) */\n")
+        for i in range(0, len(raw), 16):
+            chunk = raw[i:i + 16]
+            f.write("    " + ", ".join(f"0x{b:02X}" for b in chunk) + ",\n")
+
+
+def convert_one(png_path: Path, out_path: Path) -> None:
+    raw, w, h = png_to_ia8_bytes(png_path)
+    write_inc_c(raw, out_path, w, h)
+    print(f"  {png_path.name}  ({w}x{h}) -> {out_path.name}  [{len(raw)} bytes IA8]")
+
+
+def main(argv: list[str]) -> int:
+    p = argparse.ArgumentParser(description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter)
+    p.add_argument("--batch", action="store_true", help="treat inputs as input_dir + output_dir")
+    p.add_argument("inputs", nargs=2, metavar=("INPUT", "OUTPUT"))
+    args = p.parse_args(argv)
+
+    if args.batch:
+        in_dir = Path(args.inputs[0])
+        out_dir = Path(args.inputs[1])
+        if not in_dir.is_dir():
+            print(f"error: {in_dir} is not a directory", file=sys.stderr)
+            return 1
+        pngs = sorted(in_dir.glob("*.png"))
+        if not pngs:
+            print(f"error: no PNG files in {in_dir}", file=sys.stderr)
+            return 1
+        print(f"Converting {len(pngs)} PNGs from {in_dir} -> {out_dir}:")
+        for png in pngs:
+            out = out_dir / f"{png.stem}.tex.inc.c"
+            convert_one(png, out)
+        return 0
+    else:
+        png = Path(args.inputs[0])
+        out = Path(args.inputs[1])
+        if not png.is_file():
+            print(f"error: {png} is not a file", file=sys.stderr)
+            return 1
+        convert_one(png, out)
+        return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main(sys.argv[1:]))

--- a/tools/png_to_rgba16_inc_c.py
+++ b/tools/png_to_rgba16_inc_c.py
@@ -1,0 +1,101 @@
+#!/usr/bin/env python3
+"""
+png_to_rgba16_inc_c.py — convert RGBA PNGs to N64 RGBA5551 raw bytes as a .tex.inc.c file.
+
+For full-color sprites where IA8 (intensity + alpha) loses too much, RGBA16
+is the right format: 16 bits per pixel — 5 bits R, 5 bits G, 5 bits B, 1 bit A.
+Alpha is binary (>=128 -> 1, else 0). Each 32x32 sprite produces 2048 bytes;
+each 32x48 produces 3072 bytes.
+
+Output format matches upstream extract_inc_c.py's .tex.inc.c convention:
+    0xHH, 0xHH, ...    (16 hex bytes per line, comma-separated, trailing comma OK)
+
+Bytes are emitted in big-endian order — pixel = (R<<11) | (G<<6) | (B<<1) | A,
+high byte first, matching N64 GBI's expectation when loaded with
+G_IM_FMT_RGBA / G_IM_SIZ_16b.
+
+Usage:
+    png_to_rgba16_inc_c.py <input.png> <output.tex.inc.c>
+    png_to_rgba16_inc_c.py --batch <input_dir> <output_dir>
+"""
+
+from __future__ import annotations
+
+import argparse
+import sys
+from pathlib import Path
+
+from PIL import Image
+
+
+def png_to_rgba16_bytes(png_path: Path) -> tuple[bytearray, int, int]:
+    """Load an RGBA PNG and return (raw_rgba16_bytes_be, width, height)."""
+    img = Image.open(png_path).convert("RGBA")
+    w, h = img.size
+    px = img.load()
+    raw = bytearray(w * h * 2)
+
+    for y in range(h):
+        for x in range(w):
+            r, g, b, a = px[x, y]
+            r5 = r >> 3
+            g5 = g >> 3
+            b5 = b >> 3
+            a1 = 1 if a >= 128 else 0
+            pixel = (r5 << 11) | (g5 << 6) | (b5 << 1) | a1
+            off = (y * w + x) * 2
+            raw[off]     = (pixel >> 8) & 0xFF
+            raw[off + 1] = pixel & 0xFF
+
+    return raw, w, h
+
+
+def write_inc_c(raw: bytes, output_path: Path, width: int, height: int) -> None:
+    output_path.parent.mkdir(parents=True, exist_ok=True)
+    with open(output_path, "w", encoding="utf-8") as f:
+        f.write(f"/* Auto-generated from PNG via png_to_rgba16_inc_c.py — do not edit. */\n")
+        f.write(f"/* Format: N64 RGBA5551 ({width}x{height}, {len(raw)} bytes raw) */\n")
+        for i in range(0, len(raw), 16):
+            chunk = raw[i:i + 16]
+            f.write("    " + ", ".join(f"0x{b:02X}" for b in chunk) + ",\n")
+
+
+def convert_one(png_path: Path, out_path: Path) -> None:
+    raw, w, h = png_to_rgba16_bytes(png_path)
+    write_inc_c(raw, out_path, w, h)
+    print(f"  {png_path.name}  ({w}x{h}) -> {out_path.name}  [{len(raw)} bytes RGBA16]")
+
+
+def main(argv: list[str]) -> int:
+    p = argparse.ArgumentParser(description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter)
+    p.add_argument("--batch", action="store_true", help="treat inputs as input_dir + output_dir")
+    p.add_argument("inputs", nargs=2, metavar=("INPUT", "OUTPUT"))
+    args = p.parse_args(argv)
+
+    if args.batch:
+        in_dir = Path(args.inputs[0])
+        out_dir = Path(args.inputs[1])
+        if not in_dir.is_dir():
+            print(f"error: {in_dir} is not a directory", file=sys.stderr)
+            return 1
+        pngs = sorted(in_dir.glob("*.png"))
+        if not pngs:
+            print(f"error: no PNG files in {in_dir}", file=sys.stderr)
+            return 1
+        print(f"Converting {len(pngs)} PNGs from {in_dir} -> {out_dir}:")
+        for png in pngs:
+            out = out_dir / f"{png.stem}.tex.inc.c"
+            convert_one(png, out)
+        return 0
+    else:
+        png = Path(args.inputs[0])
+        out = Path(args.inputs[1])
+        if not png.is_file():
+            print(f"error: {png} is not a file", file=sys.stderr)
+            return 1
+        convert_one(png, out)
+        return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main(sys.argv[1:]))

--- a/tools/wav_to_pcm_inc_c.py
+++ b/tools/wav_to_pcm_inc_c.py
@@ -1,0 +1,120 @@
+#!/usr/bin/env python3
+"""
+wav_to_pcm_inc_c.py — convert a WAV file to 32 kHz interleaved-stereo S16
+PCM, emitted as int16 literals in a .pcm.inc.c file.
+
+The PC port's audio output stream feeds libultraship via
+AudioPlayerPlayFrame(buf, len) at 32 kHz, interleaved stereo S16
+(see port/audio/audio_playback.cpp). PokemonEngine's voice mixer hooks
+that function and mixes registered PCM blobs into the buffer; the format
+must match exactly or playback comes out the wrong rate / aliased.
+
+Input: any WAV that scipy.io.wavfile can read (PCM only — compressed
+WAVs unsupported). Resampled to 32000 Hz with scipy.signal.resample_poly,
+mono inputs duplicated to both channels, S16 saturating-converted.
+
+Output: a .pcm.inc.c snippet meant to be #included between
+`static const int16_t kFooPCM[] = {` and `};`. Eight values per line.
+
+Usage:
+    wav_to_pcm_inc_c.py <input.wav> <output.pcm.inc.c>
+"""
+
+from __future__ import annotations
+
+import argparse
+import sys
+from pathlib import Path
+
+import numpy as np
+from scipy.io import wavfile
+from scipy.signal import resample_poly
+
+
+TARGET_RATE = 32000
+
+
+def load_wav_as_float_stereo(wav_path: Path) -> tuple[np.ndarray, int]:
+    """Read a WAV, return (float32 stereo samples in [-1, 1], src_rate)."""
+    src_rate, data = wavfile.read(str(wav_path))
+
+    if data.dtype == np.int16:
+        norm = data.astype(np.float32) / 32768.0
+    elif data.dtype == np.int32:
+        norm = data.astype(np.float32) / 2147483648.0
+    elif data.dtype == np.uint8:
+        norm = (data.astype(np.float32) - 128.0) / 128.0
+    elif data.dtype == np.float32:
+        norm = data
+    else:
+        raise SystemExit(f"unsupported WAV sample dtype: {data.dtype}")
+
+    if norm.ndim == 1:
+        norm = np.stack([norm, norm], axis=1)
+    elif norm.shape[1] == 1:
+        norm = np.repeat(norm, 2, axis=1)
+    elif norm.shape[1] >= 2:
+        norm = norm[:, :2]
+
+    return norm, src_rate
+
+
+def resample_to_target(samples: np.ndarray, src_rate: int) -> np.ndarray:
+    """Resample float32 stereo to TARGET_RATE via polyphase filter."""
+    if src_rate == TARGET_RATE:
+        return samples
+    g = np.gcd(src_rate, TARGET_RATE)
+    up = TARGET_RATE // g
+    down = src_rate // g
+    return resample_poly(samples, up, down, axis=0).astype(np.float32)
+
+
+def to_s16(samples: np.ndarray) -> np.ndarray:
+    """Saturating float32 [-1,1] -> int16 [-32768, 32767]."""
+    clipped = np.clip(samples, -1.0, 1.0)
+    return (clipped * 32767.0).astype(np.int16)
+
+
+def write_inc_c(s16_stereo: np.ndarray, output_path: Path,
+                src_rate: int, frame_count: int) -> None:
+    """Emit interleaved S16 values, 8 per line, signed decimal literals."""
+    flat = s16_stereo.reshape(-1)
+    output_path.parent.mkdir(parents=True, exist_ok=True)
+    with open(output_path, "w", encoding="utf-8") as f:
+        f.write(f"/* Auto-generated from WAV via wav_to_pcm_inc_c.py — do not edit. */\n")
+        f.write(f"/* Format: 32 kHz stereo S16 PCM, {frame_count} frames "
+                f"({frame_count / TARGET_RATE:.3f}s, resampled from {src_rate} Hz) */\n")
+        for i in range(0, len(flat), 8):
+            chunk = flat[i:i + 8]
+            f.write("    " + ", ".join(f"{int(v):6d}" for v in chunk) + ",\n")
+
+
+def convert_one(wav_path: Path, out_path: Path) -> None:
+    floats, src_rate = load_wav_as_float_stereo(wav_path)
+    resampled = resample_to_target(floats, src_rate)
+    s16 = to_s16(resampled)
+    frame_count = s16.shape[0]
+    write_inc_c(s16, out_path, src_rate, frame_count)
+    print(f"  {wav_path.name}  ({src_rate} Hz, {floats.shape[0]} frames) "
+          f"-> {out_path.name}  ({TARGET_RATE} Hz, {frame_count} frames, "
+          f"{frame_count * 4} bytes)")
+
+
+def main(argv: list[str]) -> int:
+    p = argparse.ArgumentParser(description=__doc__,
+                                 formatter_class=argparse.RawDescriptionHelpFormatter)
+    p.add_argument("input", help="input WAV file")
+    p.add_argument("output", help="output .pcm.inc.c path")
+    args = p.parse_args(argv)
+
+    wav = Path(args.input)
+    out = Path(args.output)
+    if not wav.is_file():
+        print(f"error: {wav} is not a file", file=sys.stderr)
+        return 1
+    convert_one(wav, out)
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main(sys.argv[1:]))

--- a/workspace/template/.gitignore
+++ b/workspace/template/.gitignore
@@ -1,0 +1,2 @@
+build/
+output/

--- a/workspace/template/CMakeLists.txt
+++ b/workspace/template/CMakeLists.txt
@@ -1,0 +1,162 @@
+# BattleShip TCC mod template — packaging-only build.
+#
+# This CMakeLists doesn't compile your mod (TCC does that at runtime
+# inside the engine). It only:
+#   1. Runs tools/merge_mod.py to amalgamate src/*.c into a single
+#      preprocessed dist/<file>.c per source.
+#   2. Copies headers from include/, asset files from assets/, and
+#      manifest.json into output/.
+#   3. Writes output/build.gen — a one-line-per-source list that the
+#      engine's ScriptLoader feeds to libtcc at runtime.
+#
+# After `cmake --build .`, drop the entire output/ folder into your
+# BattleShip install's mods/ directory (or zip it as a .zip / pack as
+# .o2r for distribution).
+
+cmake_minimum_required(VERSION 3.10)
+project(BattleShipModTemplate)
+
+find_package(Python3 REQUIRED COMPONENTS Interpreter)
+
+set(PARENT_DIR ${CMAKE_CURRENT_SOURCE_DIR}/../..)
+set(LOCAL_INCLUDE_DIRS ${CMAKE_CURRENT_SOURCE_DIR}/include)
+
+set(INCLUDE_DIRS
+    ${LOCAL_INCLUDE_DIRS}
+    ${CMAKE_CURRENT_SOURCE_DIR}/src
+    ${PARENT_DIR}
+    ${PARENT_DIR}/port
+    ${PARENT_DIR}/decomp/src
+    ${PARENT_DIR}/decomp/include
+    ${PARENT_DIR}/libultraship/src
+    ${PARENT_DIR}/libultraship/include
+)
+
+file(GLOB_RECURSE SRC_FILES CONFIGURE_DEPENDS "${CMAKE_CURRENT_SOURCE_DIR}/src/*.c")
+list(FILTER SRC_FILES EXCLUDE REGEX ".*\\.inc\\.c")
+
+set(BUILD_GEN ${CMAKE_CURRENT_SOURCE_DIR}/output/build.gen)
+get_filename_component(OUTPUT_DIR ${BUILD_GEN} DIRECTORY)
+file(MAKE_DIRECTORY ${OUTPUT_DIR})
+
+set(INTERMEDIATE_OUTPUTS "")
+set(COPY_OUTPUTS "")
+set(DIST_OUTPUT ${CMAKE_CURRENT_SOURCE_DIR}/output/dist)
+
+# Generate preprocessed source file (leaves sources in output/dist)
+foreach(SOURCE_FILE ${SRC_FILES})
+    file(RELATIVE_PATH RELATIVE_FILE ${CMAKE_CURRENT_SOURCE_DIR}/src ${SOURCE_FILE})
+    set(OUTPUT_FILE ${DIST_OUTPUT}/${RELATIVE_FILE})
+    get_filename_component(INTERMEDIATE_DIR ${OUTPUT_FILE} DIRECTORY)
+
+    add_custom_command(
+        OUTPUT ${OUTPUT_FILE}
+        COMMAND ${CMAKE_COMMAND} -E make_directory ${INTERMEDIATE_DIR}
+        COMMAND Python3::Interpreter ${PARENT_DIR}/tools/merge_mod.py
+                --out ${OUTPUT_FILE}
+                --includes ${INCLUDE_DIRS}
+                --srcs ${SOURCE_FILE}
+        DEPENDS ${SOURCE_FILE} ${PARENT_DIR}/tools/merge_mod.py
+        VERBATIM
+    )
+
+    list(APPEND INTERMEDIATE_OUTPUTS ${OUTPUT_FILE})
+endforeach()
+
+# Copy headers into output folder
+foreach(INCLUDE_DIR ${LOCAL_INCLUDE_DIRS})
+    file(GLOB_RECURSE HEADER_FILES CONFIGURE_DEPENDS "${INCLUDE_DIR}/*.h")
+    foreach(HEADER_FILE ${HEADER_FILES})
+        file(RELATIVE_PATH RELATIVE_HEADER ${INCLUDE_DIR} ${HEADER_FILE})
+
+        set(OUTPUT_HEADER ${OUTPUT_DIR}/include/${RELATIVE_HEADER})
+
+        get_filename_component(HEADER_OUTPUT_DIR ${OUTPUT_HEADER} DIRECTORY)
+
+        add_custom_command(
+            OUTPUT ${OUTPUT_HEADER}
+            COMMAND ${CMAKE_COMMAND} -E make_directory ${HEADER_OUTPUT_DIR}
+            COMMAND ${CMAKE_COMMAND} -E copy_if_different ${HEADER_FILE} ${OUTPUT_HEADER}
+            DEPENDS ${HEADER_FILE}
+            VERBATIM
+        )
+
+        list(APPEND COPY_OUTPUTS ${OUTPUT_HEADER})
+    endforeach()
+endforeach()
+
+# Copy assets into output folder
+file(GLOB_RECURSE ASSET_FILES CONFIGURE_DEPENDS "${CMAKE_CURRENT_SOURCE_DIR}/assets/*")
+foreach(ASSET_FILE ${ASSET_FILES})
+    file(RELATIVE_PATH RELATIVE_ASSET ${CMAKE_CURRENT_SOURCE_DIR}/assets ${ASSET_FILE})
+
+    set(OUTPUT_ASSET ${OUTPUT_DIR}/${RELATIVE_ASSET})
+
+    get_filename_component(ASSET_OUTPUT_DIR ${OUTPUT_ASSET} DIRECTORY)
+
+    add_custom_command(
+        OUTPUT ${OUTPUT_ASSET}
+        COMMAND ${CMAKE_COMMAND} -E make_directory ${ASSET_OUTPUT_DIR}
+        COMMAND ${CMAKE_COMMAND} -E copy_if_different ${ASSET_FILE} ${OUTPUT_ASSET}
+        DEPENDS ${ASSET_FILE}
+        VERBATIM
+    )
+
+    list(APPEND COPY_OUTPUTS ${OUTPUT_ASSET})
+endforeach()
+
+# Copy manifest into output folder
+set(MANIFEST_FILE ${CMAKE_CURRENT_SOURCE_DIR}/manifest.json)
+set(OUTPUT_MANIFEST ${OUTPUT_DIR}/manifest.json)
+
+add_custom_command(
+    OUTPUT ${OUTPUT_MANIFEST}
+    COMMAND ${CMAKE_COMMAND} -E copy_if_different ${MANIFEST_FILE} ${OUTPUT_MANIFEST}
+    DEPENDS ${MANIFEST_FILE}
+    VERBATIM
+)
+list(APPEND COPY_OUTPUTS ${OUTPUT_MANIFEST})
+
+# Copy preview image if present (.png / .jpg / .jpeg). The runtime
+# loader picks the first match in that order for the Mods menu UI.
+foreach(PREVIEW_NAME preview.png preview.jpg preview.jpeg)
+    set(PREVIEW_SRC ${CMAKE_CURRENT_SOURCE_DIR}/${PREVIEW_NAME})
+    if(EXISTS ${PREVIEW_SRC})
+        set(PREVIEW_DST ${OUTPUT_DIR}/${PREVIEW_NAME})
+        add_custom_command(
+            OUTPUT ${PREVIEW_DST}
+            COMMAND ${CMAKE_COMMAND} -E copy_if_different ${PREVIEW_SRC} ${PREVIEW_DST}
+            DEPENDS ${PREVIEW_SRC}
+            VERBATIM
+        )
+        list(APPEND COPY_OUTPUTS ${PREVIEW_DST})
+    endif()
+endforeach()
+
+string(REPLACE ";" "\n" FORMATTED_FILE_LIST "${INTERMEDIATE_OUTPUTS}")
+string(REPLACE "${CMAKE_CURRENT_SOURCE_DIR}/output/" "" FORMATTED_FILE_LIST "${FORMATTED_FILE_LIST}")
+
+# Write build.gen as a build-time artifact via add_custom_command, not
+# file(WRITE) at configure time. file(WRITE) only fires on cmake
+# (re)configure, so deleting output/ and running `cmake --build` alone
+# leaves build.gen missing and the engine fails to find an entry point.
+add_custom_command(
+    OUTPUT ${BUILD_GEN}
+    COMMAND ${CMAKE_COMMAND} -E make_directory ${OUTPUT_DIR}
+    COMMAND ${CMAKE_COMMAND} -E echo "${FORMATTED_FILE_LIST}" > ${BUILD_GEN}
+    COMMENT "Writing build.gen entry-point manifest"
+    VERBATIM
+)
+list(APPEND COPY_OUTPUTS ${BUILD_GEN})
+
+add_custom_target(generate_packaged_mod ALL DEPENDS ${INTERMEDIATE_OUTPUTS} ${COPY_OUTPUTS})
+
+# When this template is built inside the engine tree, the engine's
+# cmake/ModO2R.cmake module defines ssb64_add_mod_o2r_target. Hook it
+# up so `cmake --build . --target mod_template_o2r` produces an .o2r
+# next to the output/ folder. Outside the engine build the function is
+# undefined and this is a no-op; pack manually with torch.exe in that
+# case (`torch pack output template.o2r o2r`).
+if(COMMAND ssb64_add_mod_o2r_target)
+    ssb64_add_mod_o2r_target(template)
+endif()

--- a/workspace/template/README.md
+++ b/workspace/template/README.md
@@ -1,0 +1,144 @@
+# BattleShip TCC Mod Template
+
+Starter scaffold for native C mods loaded by BattleShip's runtime TCC scripting layer (ported from Starship / Kenix3 libultraship).
+
+Your mod ships as a `.o2r` archive that wraps the same folder layout described below. The engine compiles each `.c` file at runtime via libtcc, links against `BattleShip.def` (auto-generated from the engine binary's export table), and calls `ModInit` on load / `ModExit` on unload.
+
+The runtime loader (`port/port.cpp:MountModsDir`) handles `.o2r` archives and folder layouts identically through libultraship's `ArchiveManager`, so during development you can drop the unpacked `output/` folder straight into `<install>/mods/` for fast iteration. For distribution, pack it as an `.o2r`.
+
+## Layout
+
+```
+template/
+├── CMakeLists.txt        # Packaging build: amalgamation + asset copy
+├── manifest.json         # Mod metadata (name, version, code-version, main)
+├── preview.png           # Optional. Shown in the Mods menu UI. .jpg / .jpeg also work.
+├── include/
+│   └── mod.h             # MOD_INIT / MOD_EXIT / HM_API macros
+├── src/
+│   └── demo.c            # Mod logic + event listeners
+├── assets/               # Textures, audio, etc. (copied verbatim into output/)
+└── output/               # Generated. Drop the folder into BattleShip/mods/.
+    ├── manifest.json
+    ├── preview.png       # Copied from the source folder if present.
+    ├── build.gen
+    └── dist/<file>.c
+```
+
+## Build
+
+For development iteration (folder install):
+
+```bash
+cmake -B build
+cmake --build build
+```
+
+`output/` now contains the packaged mod. Drop it into `<BattleShip-install>/mods/`. The engine reads `manifest.json`, follows `main: build.gen`, compiles each listed `dist/*.c`, and calls `ModInit`.
+
+For distribution, pack it as `.o2r`. When the template is built inside the engine tree, the engine's `cmake/ModO2R.cmake` module wires up an opt-in target:
+
+```bash
+cmake --build build --target mod_template_o2r
+```
+
+That runs `torch.exe pack output/ template.o2r o2r` and drops the archive next to `output/`. Drop the `.o2r` into `<BattleShip-install>/mods/` and the runtime loads it the same way it loads the folder.
+
+Outside the engine tree (standalone builds with no `torch.exe` on PATH), pack manually:
+
+```bash
+torch pack output/ template.o2r o2r
+```
+
+## Mod lifecycle
+
+```c
+#include "mod.h"
+#include "port/hooks/Events.h"
+
+ListenerID gFrameListenerID;
+
+void OnFrame(IEvent* event) {
+    /* per-frame logic */
+}
+
+MOD_INIT() {
+    gFrameListenerID = REGISTER_LISTENER(GamePostUpdateEvent,
+                                         EVENT_PRIORITY_NORMAL, OnFrame);
+}
+
+MOD_EXIT() {
+    UNREGISTER_LISTENER(GamePostUpdateEvent, gFrameListenerID);
+}
+```
+
+Available events live in `port/hooks/list/EngineEvent.h` (and any other `list/*.h` headers added later).
+
+## Calling engine functions
+
+Any function in BattleShip's export table is callable from your mod. The post-build step runs `tcc.exe -impdef <BattleShip.exe>` and produces `BattleShip.def`, which libtcc automatically links against. You don't have to declare engine functions — `#include` the relevant decomp / port header and call them.
+
+## Cross-mod calls
+
+If your mod depends on another mod, declare it in `manifest.json`:
+
+```json
+{
+    "name": "MyMod",
+    "dependencies": ["MyLib"],
+    ...
+}
+```
+
+The engine resolves dependency order and loads `MyLib` first. Then call into it via the symbol/typedef pair the dependency exports:
+
+```c
+#define MyLib_FooSymbol "MyLib_Foo"
+typedef int (*MyLib_FooFunc)(int x, const char *name);
+
+int slot = CALL_FUNC("MyLib", MyLib_Foo, 42, "hello");
+```
+
+`CALL_FUNC` looks up `MyLib_Foo` in the named mod's export table and calls it through the typedef. If the lookup fails (mod not loaded, symbol misspelled), it returns NULL through the function pointer and crashes on call - guard with `ScriptGetFunction` directly if you need a soft-fail.
+
+## Hooks
+
+`mod_install_hook(name, replacement, original_out)` detours a named host function so calls to it land in your replacement. The original function pointer comes back through `original_out` so you can chain it. Returns 0 on success.
+
+```c
+typedef sb32 (*orig_fn)(GObj *);
+static orig_fn s_orig = NULL;
+
+static sb32 my_replacement(GObj *g) {
+    /* preamble */
+    sb32 rv = s_orig(g);  /* call original */
+    /* postamble */
+    return rv;
+}
+
+MOD_INIT() {
+    mod_install_hook("itTomatoFallProcUpdate", my_replacement, (void **)&s_orig);
+}
+```
+
+Hooks are owned by the mod that installed them. When the mod is unloaded (engine shutdown or hot-reload), the engine removes each of its hooks cleanly before `MOD_INIT` runs again, so reloading a hook-installing mod is safe.
+
+## Resolving engine symbols at runtime
+
+Most engine calls work via `#include` + a normal call (the linker resolves them through `BattleShip.def`). For cases where you need the address of a function as data (passing a callback to vanilla code, building a function table), use:
+
+```c
+extern void *mod_resolve_symbol(const char *name);
+
+void *fn = mod_resolve_symbol("itManagerMakeItem");
+```
+
+## Logging
+
+`mod_log(fmt, ...)` routes through `port_log` and writes to `%APPDATA%/BattleShip/ssb64.log` immediately (no buffering). Format string is printf-style.
+
+In Debug builds on Windows, libultraship allocates a console at startup and redirects `stdout` / `stderr` to it, so `printf` and `fprintf(stderr, ...)` from a mod show up in that second window too. In Release builds there's no console, so stdout goes nowhere - `mod_log` is the only thing you can rely on across both configurations.
+
+## Hot reload
+
+The engine's Mods menu has a Reload action. It unloads every mod (running each `MOD_EXIT`, removing each mod's owned hooks, freeing its compiled image), recompiles every mod's sources from disk, and re-runs `MOD_INIT` on the fresh build. Works the same for listener-only mods and hook-installing mods.

--- a/workspace/template/include/mod.h
+++ b/workspace/template/include/mod.h
@@ -1,0 +1,89 @@
+/*
+ * mod.h — BattleShip native C-mod author API.
+ *
+ * #include this from your mod's .c source. The TCC scripting layer
+ * compiles your source at runtime, links against BattleShip.def
+ * (auto-generated from the engine binary's export table), and calls
+ * your ModInit / ModExit entry points.
+ *
+ * Mod lifecycle:
+ *   - Engine boot loads each mod's manifest.json, compiles its sources,
+ *     resolves ModInit by name and calls it. Subscribe to events here.
+ *   - Engine shutdown / hot-reload calls ModExit. Unregister listeners
+ *     and free anything you allocated.
+ *
+ * Symbol visibility:
+ *   - HM_API marks ModInit / ModExit as exported so the engine's
+ *     dlsym/GetProcAddress finds them. Don't use HM_API on internal
+ *     helpers — `static` is preferred.
+ *
+ * Cross-mod calls:
+ *   - ScriptGetFunction(modName, "FunctionName") returns an opaque
+ *     function pointer to a symbol in another loaded mod. Use the
+ *     CALL_FUNC helper macro for the convention `<Func>Symbol` /
+ *     `<Func>Func` typedef:
+ *
+ *       #define MyFooSymbol "MyFoo"
+ *       typedef int (*MyFooFunc)(int x);
+ *       int result = CALL_FUNC("MyLib", MyFoo, 42);
+ */
+#pragma once
+
+/* The host engine is compiled with -DPORT, which selects a different
+ * layout for many decomp structs (FTAttributes, ITAttributes, etc —
+ * pointer fields collapse to u32 reloc tokens under the PORT path).
+ * Mods MUST see the same layout, otherwise field offsets shift and
+ * cross-boundary struct reads return garbage (e.g. fp->joints[joint_id]
+ * lands on random memory mid-FTAttributes). Define before any decomp
+ * header is pulled in. */
+#ifndef PORT
+#define PORT 1
+#endif
+
+#if defined(_WIN32) || defined(__CYGWIN__)
+    #define HM_API   __declspec(dllexport)
+    #define HM_IMPORT __declspec(dllimport)
+#else
+    #define HM_API    __attribute__((visibility("default")))
+    #define HM_IMPORT
+#endif
+
+#define MOD_INIT HM_API void ModInit
+#define MOD_EXIT HM_API void ModExit
+
+extern void* ScriptGetFunction(const char* module, const char* function);
+
+#define CALL_FUNC(mod, func, ...) ((func##Func)ScriptGetFunction(mod, func##Symbol))(__VA_ARGS__)
+
+/* Logging from inside a mod.
+ *
+ * mod_log(fmt, ...) routes through the engine's port_log, which writes
+ * to %APPDATA%/BattleShip/ssb64.log. Output appears immediately
+ * (port_log fflushes after every write). Format string is printf-style.
+ *
+ * In Debug builds on Windows, libultraship allocates a console at
+ * startup and redirects stdout / stderr to it, so printf works and
+ * shows up in that window. Release builds have no console, so stdout
+ * goes nowhere. mod_log works in both configurations.
+ */
+extern HM_IMPORT void port_log(const char* fmt, ...);
+#define mod_log port_log
+
+/* Hook installation + symbol resolution.
+ *
+ * mod_install_hook(symbol_name, replacement, original_out) detours the
+ * named host function in memory: calls to it now jump to `replacement`,
+ * and `*original_out` is set to a trampoline that runs the unhooked
+ * original. Returns 0 on success.
+ *
+ * mod_resolve_symbol(symbol_name) returns the address of any host
+ * symbol by name (used to call engine functions that aren't statically
+ * resolvable from the mod, e.g. when the function pointer is needed).
+ *
+ * Hooks are owned by the mod that installed them. When the mod is
+ * unloaded (engine shutdown or hot-reload), HookManager walks the
+ * mod's chain and removes each hook cleanly, so reloading a hook-
+ * installing mod is safe.
+ */
+extern HM_IMPORT int   mod_install_hook(const char* symbol_name, void* replacement, void** original_out);
+extern HM_IMPORT void* mod_resolve_symbol(const char* symbol_name);

--- a/workspace/template/manifest.json
+++ b/workspace/template/manifest.json
@@ -1,0 +1,10 @@
+{
+    "name": "Demo Mod",
+    "main": "build.gen",
+    "version": "1.0.0",
+    "website": "https://example.com",
+    "description": "A simple demo mod for testing the BattleShip TCC scripting layer.",
+    "author": "Your Name",
+    "license": "MIT",
+    "code-version": 1
+}

--- a/workspace/template/src/demo.c
+++ b/workspace/template/src/demo.c
@@ -1,0 +1,36 @@
+/*
+ * demo.c — minimal BattleShip TCC mod sample.
+ *
+ * Subscribes to GamePostUpdateEvent and prints a heartbeat once per
+ * second to the engine's log. This is the simplest possible mod shape:
+ * ModInit registers a listener, ModExit unregisters it.
+ *
+ * To extend:
+ *   - Subscribe to additional events from port/hooks/list/EngineEvent.h.
+ *   - Call into engine functions that are exported in BattleShip.def
+ *     (auto-generated post-build via tcc.exe -impdef).
+ *   - Cross-mod calls go through ScriptGetFunction("ModName", "func").
+ */
+#include "mod.h"
+
+#include "port/hooks/Events.h"
+
+ListenerID gFrameUpdateListenerID;
+static unsigned gFrames = 0;
+
+void OnFrameUpdate(IEvent* event) {
+    gFrames++;
+    if ((gFrames % 60) == 0) {
+        mod_log("[DemoMod] frame heartbeat: %u\n", gFrames);
+    }
+}
+
+MOD_INIT() {
+    gFrameUpdateListenerID = REGISTER_LISTENER(GamePostUpdateEvent, EVENT_PRIORITY_NORMAL, OnFrameUpdate);
+    mod_log("[DemoMod] init OK\n");
+}
+
+MOD_EXIT() {
+    UNREGISTER_LISTENER(GamePostUpdateEvent, gFrameUpdateListenerID);
+    mod_log("[DemoMod] exit OK (saw %u frames)\n", gFrames);
+}


### PR DESCRIPTION
# Add TCC mod loader and workspace template

## What this adds

The runtime side of TCC source-compiled mods. Mods drop into `mods/`
next to the executable as folders or `.o2r` archives. At startup the
engine compiles each mod's `.c` source via libtcc, links it against
`BattleShip.def`, and calls `ModInit`. The Mods menu has a Hot Reload
button that unloads everything, recompiles from disk, and re-runs
`ModInit`.

## Files

- `port/mods/` (new): HookManager (per-mod hook ownership + safe
  hot-reload), SymbolResolver (engine symbol lookup by name),
  mod_bridge (`mod_install_hook` + `mod_resolve_symbol` exposed via
  `BattleShip.def` for mods to call).
- `port/hooks/` (new): event firing system. Mods subscribe with
  `REGISTER_LISTENER` from `MOD_INIT`. Engine events fire from
  `port.cpp` and `gameloop.cpp`.
- `port/audio/mixer.{c,h}` (new): PCM voice mixer hooked into
  `AudioPlayerPlayFrame` so mods can play custom audio.
- `port/gui/PortMenu.cpp`: adds a Mods section with a Reload button.
- `port/port.cpp`: brings up SymbolResolver / HookManager at startup,
  mounts `mods/`, runs ScriptLoader `CompileAll` + `LoadAll`. Tears
  down in reverse on shutdown.
- `port/gameloop.cpp`: fires the per-frame engine event so mods can
  hook into the frame loop.
- `tools/merge_mod.py` (new): the asset preprocessor and TU
  amalgamator every mod's CMakeLists invokes. Walks `.c` includes,
  decodes PNG/WAV/AIFC assets to N64-format inline bytes, and
  produces the single `.c` file libtcc compiles.
- `tools/{aifc_to_wav,wav_to_pcm_inc_c,png_to_rgba16_inc_c,
  png_to_ia8_inc_c}.py` (new): asset converters for authoring.
- `workspace/template/` (new): starter scaffold for new mods with
  `manifest.json`, `CMakeLists`, `mod.h`, `demo.c`, README.
- `cmake/ModO2R.cmake` (new): `ssb64_add_mod_o2r_target()` helper
  that wires `cmake --build . --target mod_<NAME>_o2r` to
  `torch.exe pack`.
- `CMakeLists.txt`: vendors MinHook via FetchContent for the runtime
  detour primitive, copies libtcc headers and the runtime DLL into
  the build dir, generates `BattleShip.def` via `tcc -impdef`
  post-build.

## What's not in this PR

- No mods. `workspace/` ships only the template.
- No libultraship changes (separate PR). The submodule pointer
  bump in this PR depends on that PR landing first.

## Dependencies

requires [this LUS PR ](https://github.com/JRickey/libultraship/pull/2)

## How to test

- Build clean and launch with no `mods/` directory; engine should
  run normally with the loader idle.
- Drop `workspace/template/output/` into `<install>/mods/` as a
  folder and relaunch. Engine logs `Initializing script: template`
  in `ssb64.log`; the demo mod's `MOD_INIT` runs.
- Pack the same template as `.o2r` via
  `cmake --build . --target mod_template_o2r`, drop the `.o2r` in
  `mods/`, relaunch. Same behavior.
- In the Mods menu, edit `src/demo.c`, run `cmake --build .` in the
  template, click Hot Reload. `ssb64.log` shows the unload +
  recompile + re-init cycle without restarting the engine.

## Notes for review

- HookManager uses MinHook. Mods' `MOD_INIT` runs inside a
  `SetCurrentOwner` / `ClearCurrentOwner` wrapper so every
  `InstallHook` call gets tagged. `UnloadAll` calls
  `UninstallHooksForOwner` per mod before the mod's PE image is
  freed. This is the part most likely to bite if mod lifecycle
  order changes.
- Mod source in `workspace/<NAME>` isn't compiled by the engine
  build; `merge_mod.py` just preprocesses + copies. The runtime
  compile happens via libtcc when the mod loads. So mod build
  errors don't surface until launch + `ssb64.log`.
- `mod_bridge.cpp` is anchored explicitly in `port.cpp` so the
  linker doesn't drop the bridge `.obj` at link time. If a future
  `port.cpp` refactor removes those anchor lines, mods stop being
  able to resolve `mod_install_hook` / `mod_resolve_symbol`.

## Suggestions welcome

- Where or even whether the `workspace/` folder belongs in the repo or in the shipyard (unsure of its current status).
- Whether the `merge_mod.py` tooling makes sense at `tools/` root
  or under `tools/mods/`. or if any of the mod related tools belong in here or in the shipyard.

based on this [Starship PR](https://github.com/HarbourMasters/Starship/pull/255)