### PR TITLE
Remove Battle-ShipYard submodule and from-source reloc pipeline

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -10,6 +10,3 @@
 	path = decomp
 	url = https://github.com/JRickey/ssb-decomp-re.git
 	branch = port-patches
-[submodule "Battle-ShipYard"]
-	path = Battle-ShipYard
-	url = https://github.com/JRickey/Battle-ShipYard.git

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -477,21 +477,15 @@ endif()
 #
 #   (a) Baserom present (typical dev / Torch-extract first-run): declare the
 #       o2r as an add_custom_command(OUTPUT ...) so downstream rules that
-#       DEPENDS on it as a file (notably Battle-ShipYard's passthrough_reloc
-#       commands) connect to this producer through CMake's file-level
-#       dependency graph. The wrapping custom_target keeps
+#       DEPENDS on it as a file connect to this producer through CMake's
+#       file-level dependency graph. The wrapping custom_target keeps
 #       `cmake --build . --target ExtractAssets` working.
 #
 #   (b) Baserom absent (CI release pipeline never ships the copyrighted ROM):
 #       provide a stub ExtractAssets target that fails with a clear error if
-#       invoked, but does NOT register the file-level rule. Without the rule
-#       Ninja correctly skips the source-compile pipeline (which transitively
-#       depends on the o2r) instead of erroring with "no rule to make target".
-#       Any caller that genuinely needs the o2r will hit ExtractAssets and
-#       get the explanatory error.
-#
-# `finalize_battleship_from_source` below additionally gates on the baserom,
-# so case (b) doesn't even register the source-compile target.
+#       invoked, but does NOT register the file-level rule. Any caller that
+#       genuinely needs the o2r will hit ExtractAssets and get the
+#       explanatory error.
 if(EXISTS "${SSB64_BASEROM}")
     add_custom_command(
         OUTPUT ${CMAKE_SOURCE_DIR}/BattleShip.o2r
@@ -511,8 +505,7 @@ else()
         COMMAND ${CMAKE_COMMAND} -E false
         COMMENT "ExtractAssets stub — baserom missing"
     )
-    message(STATUS "BattleShip.o2r: baserom absent — ExtractAssets stub installed; "
-                   "source-compile pipeline will be disabled (released artifacts ship without .fromsource.o2r)")
+    message(STATUS "BattleShip.o2r: baserom absent — ExtractAssets stub installed")
 endif()
 
 add_custom_target(GenerateBattleShipO2R
@@ -525,38 +518,3 @@ add_custom_target(GeneratePortO2R
     COMMAND ${TORCH_EXECUTABLE} pack ${CMAKE_SOURCE_DIR}/assets ${CMAKE_SOURCE_DIR}/ssb64.o2r o2r
     COMMENT "Packing port-specific assets into ssb64.o2r"
 )
-
-################################################################################
-# RelocData compile-from-source pipeline (Battle-ShipYard modkit)
-#
-# When a compatible toolchain is available (LLVM/clang or VS x86 cl.exe via
-# vcvars32), builds BattleShip.fromsource.o2r alongside the executable.
-# Loaded ahead of BattleShip.o2r at runtime when SSB64_RELOC_FROMSOURCE=1,
-# shadowing Torch entries for matching paths. With no toolchain the entire
-# subsystem is skipped — runtime falls back to Torch-extracted reloc data
-# exactly as before.
-#
-# The pipeline lives in the Battle-ShipYard submodule
-# (https://github.com/JRickey/Battle-ShipYard). Bumping the submodule
-# pointer is how we ship modkit changes; nothing in this repo's CMakeLists
-# needs to change for routine modkit updates. The contract is the variables
-# set below — DECOMP_DIR for the source tree, RELOC_TABLE for the file_id
-# mapping. Compiler discovery, eligible-set generation, per-file build
-# rules, and finalize_battleship_from_source all live in the submodule.
-################################################################################
-
-set(RELOCDATA_DECOMP_DIR  "${CMAKE_SOURCE_DIR}/decomp")
-set(RELOCDATA_RELOC_TABLE "${CMAKE_SOURCE_DIR}/port/resource/RelocFileTable.cpp")
-# ExtractAssets writes BattleShip.o2r to ${CMAKE_SOURCE_DIR}; tell the modkit
-# to make BuildBattleShipFromSource depend on it so the source-compile +
-# passthrough commands don't race on a fresh `cmake -B && cmake --build` flow
-# (the failure mode that broke v0.7.6-beta packaging).
-set(RELOCDATA_BATTLESHIP_O2R_TARGET ExtractAssets)
-include(Battle-ShipYard/cmake/RelocData.cmake)
-
-if(RELOCDATA_CC AND EXISTS "${SSB64_BASEROM}")
-    finalize_battleship_from_source(${CMAKE_BINARY_DIR}/BattleShip.fromsource.o2r)
-elseif(RELOCDATA_CC)
-    message(STATUS "RelocData: baserom absent — BuildBattleShipFromSource skipped "
-                   "(release CI / no-rom builds; runtime falls back to Torch-passthrough reloc data)")
-endif()

--- a/LICENSE
+++ b/LICENSE
@@ -72,9 +72,6 @@ It does NOT extend to:
     licensed independently by its upstream maintainers under the MIT License:
       Copyright (c) 2023 Lywx <admin@undervolt.dev>
     Torch is maintained by the Harbour Masters team.
-  * The `Battle-ShipYard/` modding-toolkit submodule
-    (https://github.com/JRickey/Battle-ShipYard), licensed independently
-    under the MIT License (see its own `LICENSE`).
   * The font assets bundled under `assets/custom/fonts/`, which are licensed
     under the SIL Open Font License, Version 1.1:
       - Montserrat (Copyright 2011 The Montserrat Project Authors,

--- a/README.md
+++ b/README.md
@@ -48,11 +48,6 @@ All Powered by LibultraShip
 
 ## Rollback Netcode and Online Play (WORK IN PROGRESS)
 
-## Mod Loader and Toolkit (WORK IN PROGRESS)
-
-- Modding Toolkit is available as a submodule [Battle-ShipYard](https://github.com/JRickey/Battle-ShipYard)
-- Mod loader is Work in Progress
-
 ## Author's notes
 
 ### About the project
@@ -105,7 +100,7 @@ The port has three layers and they are kept deliberately separate:
 
 `baserom.us.z64` is never read at runtime. At build time, **Torch** walks the ROM with the YAMLs under `yamls/us/` and emits `BattleShip.o2r` — a zip-format archive of typed resources (textures, sequences, sample banks, animations, reloc files). At launch, libultraship's resource manager mounts `BattleShip.o2r` + `f3d.o2r` and the port code requests resources by path. This is the same pipeline used by Ship of Harkinian, Starship, SpaghettiKart, etc.
 
-The relocatable-data files (fighter tables, item tables, effects, sprites) are SSB64-specific and required custom factories on the Torch side and a custom loader (`port/resource/RelocFileFactory.cpp`) on the runtime side. They can also be built straight from decomp source — the [Battle-ShipYard](https://github.com/JRickey/Battle-ShipYard) submodule recompiles `decomp/src/relocData/*.c` end-to-end (i686 cross-compile → ELF/COFF parse → byteswap to BE → reloc-chain encoding → LUS RelocFile resource emit) into a parallel `BattleShip.fromsource.o2r` archive that the runtime loads ahead of the Torch-extracted bytes when `SSB64_RELOC_FROMSOURCE=1` is set, shadowing matching entries via LUS's FIFO ArchiveManager lookup. Both archives feed the same `RelocFileFactory.cpp` loader. See the **Modding** section below.
+The relocatable-data files (fighter tables, item tables, effects, sprites) are SSB64-specific and required custom factories on the Torch side and a custom loader (`port/resource/RelocFileFactory.cpp`) on the runtime side.
 
 ### Build-time codegen
 
@@ -116,8 +111,6 @@ A small amount of generated code lives outside the source tree (gitignored) and 
 - `port/resource/RelocFileTable.cpp` — the runtime symbol table
 
 If you ever see "undefined reference to `dFooBarReloc`" you regenerated the table without rebuilding, or vice versa.
-
-When a clang or MSVC toolchain is on the build host, the [Battle-ShipYard](https://github.com/JRickey/Battle-ShipYard) submodule additionally produces `BattleShip.fromsource.o2r` at build time — 1,870 source-compiled relocData files plus 262 passthroughs, runtime-equivalent to the Torch-extracted bytes (verified by the toolkit's symbol-aligned equivalence validator). The archive is optional: with no toolchain available the build proceeds with Torch-extracted reloc data only and the runtime is unchanged.
 
 ---
 
@@ -207,21 +200,6 @@ Both forks live as submodules so their history stays their own and so upstream c
 
 ---
 
-## Modding
-
-Source-level modding is supported via the [Battle-ShipYard](https://github.com/JRickey/Battle-ShipYard) submodule — a CMake-driven toolkit that recompiles `decomp/src/relocData/*.c` (fighter attributes, animations, stage data, particle effects, weapon hitboxes — anything the runtime relocates from a per-file body) into a sideloadable `BattleShip.fromsource.o2r`. Drop the archive next to your `BattleShip.exe` and launch with `SSB64_RELOC_FROMSOURCE=1` in the environment to load it ahead of the ROM-extracted data.
-
-Either toolchain works:
-
-- **clang** (any host) — `winget install LLVM.LLVM` on Windows, ships with Xcode CLI tools on macOS, `apt install clang` on Linux.
-- **MSVC** (Windows only) — VS 2017+ or Build Tools with the *Desktop development with C++* workload. Auto-detected via `vswhere`; the toolkit captures `vcvars32` once at configure time and runs `cl.exe` through a generated env wrapper, so no Developer Shell launch is required.
-
-Both backends produce runtime-equivalent archives across the full 1,870-file eligible-set — verified by the modkit's symbol-aligned equivalence validator. The remaining ~262 files (JP-only overlays, files needing upstream `.inc.c` extracts, IDO bitfield-init structs) are passed through unchanged from the Torch-extracted bytes.
-
-A mod loader for installing and managing multiple mods at runtime is planned but not yet implemented; for now, sideloading is one-archive-at-a-time via the env var. See the [Battle-ShipYard README](https://github.com/JRickey/Battle-ShipYard#readme) for the full toolkit reference, per-tool docs, and the build flow for both standalone and submodule usage.
-
----
-
 ## Repo layout
 
 ```
@@ -235,10 +213,9 @@ decomp/       submodule — decompiled SSB64 C source (largely unchanged
                 src/ft/         fighters (ftmario/, ftkirby/, ftfox/, …)
                 src/sc/ gm/ gr/ scene / game modes / stage rendering
                 src/mn/ it/ ef/ menus / items / effects
-                src/relocData/  reloc data sources (Battle-ShipYard input)
+                src/relocData/  reloc data sources
 libultraship/ submodule — PC-native render / audio / input / resource mgr
 torch/        submodule — asset extractor (ROM → BattleShip.o2r)
-Battle-ShipYard/  submodule — modding toolkit (decomp source → BattleShip.fromsource.o2r)
 yamls/us/     Torch YAML extraction configs (some generated)
 tools/        Python helpers: reloc stubs, YAML gen, credits encoder
 docs/         architecture notes, bug write-ups, debugging guides
@@ -284,7 +261,7 @@ This project is **not affiliated with, endorsed by, or authorized by Harbour Mas
 
 ## License
 
-Source code in this repository (everything outside the `decomp/`, `libultraship/`, `torch/`, and `Battle-ShipYard/` submodules — each of which carries its own attribution) is released under the [MIT License](LICENSE) — free to use, modify, and redistribute, with no warranty and no liability. See [`LICENSE`](LICENSE) for the full text.
+Source code in this repository (everything outside the `decomp/`, `libultraship/`, and `torch/` submodules — each of which carries its own attribution) is released under the [MIT License](LICENSE) — free to use, modify, and redistribute, with no warranty and no liability. See [`LICENSE`](LICENSE) for the full text.
 
 The MIT grant covers only the port-specific code (the `port/` layer, build scripts, tools, docs). It does **not** extend to:
 - Game assets, code, audio, textures, models, or any other content owned by Nintendo / HAL Laboratory — none of which is in this repository.
@@ -292,5 +269,4 @@ The MIT grant covers only the port-specific code (the `port/` layer, build scrip
 - Decomp-derived content elsewhere in the tree (vendored or auto-generated from the decomp's symbol/file-name tables): `tools/reloc_data_symbols.us.txt`, `tools/relocFileDescriptions.us.txt`, `include/reloc_data.h`, `port/resource/RelocFileTable.cpp`, and `yamls/us/reloc_*.yml`. These follow the same upstream-deference as the `decomp/` submodule. The generator scripts that produce them (`tools/generate_*.py`) are port-authored and remain MIT.
 - The `libultraship` submodule — Copyright (c) 2022 kenix3, MIT-licensed (originated by the Harbour Masters team).
 - The `torch` submodule — Copyright (c) 2023 Lywx (Harbour Masters), MIT-licensed.
-- The `Battle-ShipYard` modkit submodule, which is MIT-licensed under its own [LICENSE](https://github.com/JRickey/Battle-ShipYard/blob/main/LICENSE).
 - The bundled menu fonts under `assets/custom/fonts/`, which are licensed under the SIL Open Font License 1.1 (per-font license files in that directory).

--- a/port/port.cpp
+++ b/port/port.cpp
@@ -564,30 +564,6 @@ static int PortInitImpl(int argc, char* argv[]) {
 		// Add BattleShip.o2r to the running ResourceManager now that it exists.
 		auto am = sContext->GetResourceManager()->GetArchiveManager();
 
-		// Optional: BattleShip.fromsource.o2r contains relocData resources
-		// produced by compiling decomp/src/relocData/*.c via the source-
-		// compile pipeline (tools/build_reloc_resource.py). Adding it BEFORE
-		// the Torch-extracted BattleShip.o2r means the LUS ArchiveManager's
-		// FIFO-wins lookup serves source-compiled entries for matching
-		// resource paths. The file is gitignored / produced by the
-		// BuildBattleShipFromSource CMake target, which is gated on clang
-		// availability — when missing the load is silently skipped and
-		// runtime behaves exactly as the pre-M2 Torch-only path.
-		if (const char *fromsource = std::getenv("SSB64_RELOC_FROMSOURCE");
-			fromsource && fromsource[0] == '1') {
-			const std::string fs = PortLocateFile("BattleShip.fromsource.o2r");
-			if (!fs.empty()) {
-				port_log("SSB64: SSB64_RELOC_FROMSOURCE=1 -> adding %s ahead of BattleShip.o2r\n",
-				         fs.c_str());
-				if (!am->AddArchive(fs)) {
-					port_log("SSB64: AddArchive failed for %s (continuing with Torch-extracted reloc data)\n",
-					         fs.c_str());
-				}
-			} else {
-				port_log("SSB64: SSB64_RELOC_FROMSOURCE=1 set but BattleShip.fromsource.o2r not found\n");
-			}
-		}
-
 		const std::string ssb64o2r = PortLocateFile("BattleShip.o2r");
 		port_log("SSB64: adding game archive -> %s\n", ssb64o2r.c_str());
 		if (!am->AddArchive(ssb64o2r)) {

--- a/scripts/new-worktree.sh
+++ b/scripts/new-worktree.sh
@@ -11,8 +11,8 @@
 # What it does:
 #   1. Creates a worktree at .claude/worktrees/<slug> on new branch agent/<slug>
 #   2. Symlinks baserom.us.z64 (gitignored, too big to duplicate)
-#   3. Clones libultraship, torch, decomp, and Battle-ShipYard as independent
-#      repos inside the worktree:
+#   3. Clones libultraship, torch, and decomp as independent repos inside
+#      the worktree:
 #        - Source = main tree's local submodule checkout (picks up pinned SHAs
 #          that may only exist locally, never pushed to the fork)
 #        - Origin URL reset to the real SSH upstream from .gitmodules, so
@@ -22,9 +22,8 @@
 #
 # Resulting worktree is fully editable:
 #   - Edit any file in decomp/src/, decomp/include/, port/, libultraship/,
-#     torch/, Battle-ShipYard/
-#   - Commit normally inside libultraship/ / torch/ / Battle-ShipYard/, then
-#     push to the fork
+#     torch/
+#   - Commit normally inside libultraship/ / torch/, then push to the fork
 #   - In the outer worktree: `git add libultraship && git commit` bumps the
 #     submodule pointer; push that commit up when merging back to main.
 #
@@ -96,10 +95,10 @@ ln -sf "$ROM_SRC" "$WT_DIR/baserom.us.$ROM_EXT"
 # Instead: clone from the main tree's working submodule (git follows the
 # .git gitfile → .git/modules/<name>), then reset origin to the real SSH
 # upstream so pushes from the worktree go to GitHub.
-for sm in libultraship torch decomp Battle-ShipYard; do
+for sm in libultraship torch decomp; do
     # Some submodules may not be registered on older base branches
-    # (e.g. `decomp` was added on agent/decomp-submodule, `Battle-ShipYard`
-    # came later). Skip silently if the main tree doesn't track it yet.
+    # (e.g. `decomp` was added on agent/decomp-submodule). Skip silently
+    # if the main tree doesn't track it yet.
     if [[ -z "$(git -C "$WT_DIR" config -f .gitmodules "submodule.$sm.path" 2>/dev/null)" ]]; then
         printf '\033[33m  Skipping submodule %s (not configured in main tree .gitmodules)\033[0m\n' "$sm"
         continue
@@ -202,7 +201,7 @@ cat <<EOF
   Branch:   $BRANCH  (base: $BASE)
   Build:    $WT_DIR/build       ($GEN, $CONFIG)
   ROM:      symlinked
-  Submods:  libultraship, torch, decomp, Battle-ShipYard — independent clones,
+  Submods:  libultraship, torch, decomp — independent clones,
             origin set to fork
 
   Point a new Claude window at: $WT_DIR


### PR DESCRIPTION
## Summary

- Removes the Battle-ShipYard submodule and the from-source relocData pipeline (`BattleShip.fromsource.o2r`, `SSB64_RELOC_FROMSOURCE`).
- The pipeline broke Release builds on Windows: missing `_relocdata_msvc_env.bat` wrapper on the clang-backend path, plus a cp1252 `UnicodeDecodeError` in `extract_inc_c.py` when reading `BattleShip.o2r`. Runtime now always uses Torch-extracted reloc data — the path that was already the fallback when the modkit wasn't built.

### What changed

- `CMakeLists.txt` — RelocData block deleted; ExtractAssets comments trimmed.
- `port/port.cpp` — `SSB64_RELOC_FROMSOURCE` archive-load block deleted.
- `README.md`, `LICENSE` — Battle-ShipYard mentions stripped.
- `scripts/new-worktree.sh` — submodule list pruned to `libultraship`, `torch`, `decomp`.
- `.gitmodules` / `Battle-ShipYard` — submodule removed.

## Test plan

- [x] Windows: `cmake -S . -B build/x64 -A x64` clean configure on wiped build dir
- [x] Windows Debug: `cmake --build build\x64 --config Debug --target ssb64` clean
- [x] Windows Release: `cmake --build build\x64 --config Release` clean
- [ ] macOS / Linux configure + build regression check
- [ ] Runtime smoke (game launches, reaches title screen) — needs baserom locally

🤖 Generated with [Claude Code](https://claude.com/claude-code)