### PR TITLE
Menu: Low Resolution Mode dropdown with pixel-perfect integer scaling

### DIFF
--- a/port/gui/PortMenu.cpp
+++ b/port/gui/PortMenu.cpp
@@ -53,6 +53,17 @@ static const std::map<int32_t, const char*> kTextureFilteringMap = {
     { Fast::FILTER_NONE, "None" },
 };
 
+// Mirrors the LowResMode switch in libultraship Gui::CalculateGameViewport /
+// Gui::DrawGame. 0 keeps the framebuffer at the window resolution; 1 forces a
+// 320x240 4:3 framebuffer centered with side strips; 2/3 keep the window's
+// aspect but lock vertical pixel count.
+static const std::map<int32_t, const char*> kLowResModeMap = {
+    { 0, "Off (window resolution)" },
+    { 1, "N64 (320x240, 4:3 centered)" },
+    { 2, "240p (window aspect)" },
+    { 3, "480p (window aspect)" },
+};
+
 // Mirrors dbObjectDisplayMode (src/sys/develop.h). 0 disables the override and
 // returns the engine's normal rendering.
 static const std::map<int32_t, const char*> kHitboxViewMap = {
@@ -238,6 +249,19 @@ void PortMenu::AddMenuSettings() {
                      .IsPercentage()
                      .Min(0.5f)
                      .Max(2.0f));
+
+    AddWidget(path, "Low Resolution Mode (Needs reload)", WIDGET_CVAR_COMBOBOX)
+        .CVar("gLowResModePending")
+        .RaceDisable(false)
+        .Options(ComboboxOptions()
+                     .Tooltip("Forces the internal framebuffer to a low resolution. "
+                              "N64 mode renders at 320x240 and pillarboxes to 4:3 inside the window. "
+                              "240p / 480p lock vertical pixel count while matching the window's aspect. "
+                              "Overrides Internal Resolution while active. "
+                              "Latched at startup — changes take effect on next launch (toggling mid-session "
+                              "would resize the framebuffer and race the Metal renderer).")
+                     .ComboMap(kLowResModeMap)
+                     .DefaultIndex(0));
 
 #ifndef __WIIU__
     AddWidget(path, "Anti-aliasing (MSAA)", WIDGET_CVAR_SLIDER_INT)

--- a/port/gui/PortMenu.cpp
+++ b/port/gui/PortMenu.cpp
@@ -57,11 +57,20 @@ static const std::map<int32_t, const char*> kTextureFilteringMap = {
 // Gui::DrawGame. 0 keeps the framebuffer at the window resolution; 1 forces a
 // 320x240 4:3 framebuffer centered with side strips; 2/3 keep the window's
 // aspect but lock vertical pixel count.
+// Keys 0..3 hand off to libultraship's gLowResMode (Gui.cpp LowResMode switch);
+// keys 4..7 take the PixelPerfectMode path of gAdvancedResolution and ignore
+// gLowResMode. port.cpp's boot latch translates the pending menu value into
+// the right combination of LUS cvars so libultraship sees a stable state for
+// the whole session.
 static const std::map<int32_t, const char*> kLowResModeMap = {
     { 0, "Off (window resolution)" },
-    { 1, "N64 (320x240, 4:3 centered)" },
-    { 2, "240p (window aspect)" },
-    { 3, "480p (window aspect)" },
+    { 1, "N64 (320x240, stretched 4:3)" },
+    { 2, "240p (window aspect, stretched)" },
+    { 3, "480p (window aspect, stretched)" },
+    { 4, "N64 integer-scaled (auto-fit, pixel-perfect)" },
+    { 5, "N64 integer-scaled (2x, pixel-perfect)" },
+    { 6, "N64 integer-scaled (3x, pixel-perfect)" },
+    { 7, "N64 integer-scaled (4x, pixel-perfect)" },
 };
 
 // Mirrors dbObjectDisplayMode (src/sys/develop.h). 0 disables the override and
@@ -255,8 +264,10 @@ void PortMenu::AddMenuSettings() {
         .RaceDisable(false)
         .Options(ComboboxOptions()
                      .Tooltip("Forces the internal framebuffer to a low resolution. "
-                              "N64 mode renders at 320x240 and pillarboxes to 4:3 inside the window. "
-                              "240p / 480p lock vertical pixel count while matching the window's aspect. "
+                              "Stretched modes scale the framebuffer to fill the game viewport. "
+                              "Pixel-perfect modes render N64-native 320x240 and draw it at an integer "
+                              "factor, centred with black borders — sharper retro look, no sub-pixel blur. "
+                              "Auto-fit picks the largest factor that still fits in the window. "
                               "Overrides Internal Resolution while active. "
                               "Latched at startup — changes take effect on next launch (toggling mid-session "
                               "would resize the framebuffer and race the Metal renderer).")

--- a/port/port.cpp
+++ b/port/port.cpp
@@ -411,24 +411,67 @@ static int PortInitImpl(int argc, char* argv[]) {
 		const bool widescreen_on = cv->GetInteger("gEnhancements.Widescreen", 1) != 0;
 		cv->SetFloat("gAdvancedResolution.AspectRatioX", 4.0f);
 		cv->SetFloat("gAdvancedResolution.AspectRatioY", 3.0f);
-		cv->SetInteger("gAdvancedResolution.Enabled", widescreen_on ? 0 : 1);
 
-		/* Latch gLowResMode at boot. libultraship's Gui::CalculateGameViewport
-		 * reads gLowResMode every frame and rewrites mCurDimensions, which
-		 * forces a Fast3D framebuffer reallocation. Doing that mid-session
-		 * races against the ImGui Metal backend: the per-frame ImGui::Image
-		 * cmd captures the old MTLTexture pointer at submit, but the FB
-		 * resource releases it on dim change before Metal's encoder retains
-		 * the texture, so the next setFragmentTexture: objc_retain hits a
-		 * freed object and SIGSEGVs (the same hazard documented above for
-		 * the widescreen toggle). The menu writes the user's choice to
-		 * gLowResModePending; we copy it here so LUS sees a constant
-		 * gLowResMode for the entire session and the FB resize only ever
-		 * happens at startup. */
+		/* Latch the Low Resolution Mode menu choice at boot. libultraship's
+		 * Gui::CalculateGameViewport / Gui::DrawGame read gLowResMode and the
+		 * gAdvancedResolution.* cvars every frame and rewrite mCurDimensions,
+		 * which forces a Fast3D framebuffer reallocation. Toggling these
+		 * mid-session races the ImGui Metal backend: the per-frame
+		 * ImGui::Image cmd captures the old MTLTexture pointer at submit,
+		 * but the FB resource releases it on dim change before Metal's
+		 * encoder retains the texture, so the next setFragmentTexture:
+		 * objc_retain hits a freed object and SIGSEGVs (same hazard
+		 * documented above for the widescreen toggle). The menu writes the
+		 * user's choice to gLowResModePending; we translate it into the
+		 * right set of LUS cvars here, once per launch.
+		 *
+		 *   0  Off — window-resolution framebuffer
+		 *   1  N64 stretched 4:3       (gLowResMode=1)
+		 *   2  240p window aspect      (gLowResMode=2)
+		 *   3  480p window aspect      (gLowResMode=3)
+		 *   4..7  N64 pixel-perfect integer scale (PixelPerfectMode path,
+		 *        fixed 320x240 framebuffer via VerticalResolutionToggle=1
+		 *        + VerticalPixelCount=240, factor selected by sub-key) */
 		if (cv->Get("gLowResModePending") == nullptr) {
 			cv->SetInteger("gLowResModePending", cv->GetInteger("gLowResMode", 0));
 		}
-		cv->SetInteger("gLowResMode", cv->GetInteger("gLowResModePending", 0));
+		const int32_t mode = cv->GetInteger("gLowResModePending", 0);
+
+		int32_t low_res_mode = 0;
+		bool integer_scale = false;
+		int32_t integer_factor = 1;
+		bool integer_auto_fit = false;
+		switch (mode) {
+			case 1: low_res_mode = 1; break;
+			case 2: low_res_mode = 2; break;
+			case 3: low_res_mode = 3; break;
+			case 4: integer_scale = true; integer_auto_fit = true; break;
+			case 5: integer_scale = true; integer_factor = 2; break;
+			case 6: integer_scale = true; integer_factor = 3; break;
+			case 7: integer_scale = true; integer_factor = 4; break;
+			default: break;
+		}
+
+		cv->SetInteger("gLowResMode", low_res_mode);
+		if (integer_scale) {
+			/* PixelPerfect path needs Enabled=1 regardless of widescreen so
+			 * ApplyResolutionChanges runs; with VerticalResolutionToggle=1
+			 * and a 4:3 AspectRatio, mCurDimensions resolves to 320x240, then
+			 * DrawGame's pixel-perfect branch draws it at integer factor. */
+			cv->SetInteger("gAdvancedResolution.Enabled", 1);
+			cv->SetInteger("gAdvancedResolution.VerticalResolutionToggle", 1);
+			cv->SetInteger("gAdvancedResolution.VerticalPixelCount", 240);
+			cv->SetInteger("gAdvancedResolution.PixelPerfectMode", 1);
+			cv->SetInteger("gAdvancedResolution.IntegerScale.FitAutomatically", integer_auto_fit ? 1 : 0);
+			cv->SetInteger("gAdvancedResolution.IntegerScale.Factor", integer_factor);
+			cv->SetInteger("gAdvancedResolution.IntegerScale.NeverExceedBounds", 1);
+		} else {
+			/* Restore the widescreen-driven 4:3 pillarbox default when no
+			 * integer-scale mode is selected. */
+			cv->SetInteger("gAdvancedResolution.Enabled", widescreen_on ? 0 : 1);
+			cv->SetInteger("gAdvancedResolution.VerticalResolutionToggle", 0);
+			cv->SetInteger("gAdvancedResolution.PixelPerfectMode", 0);
+		}
 
 		/* Issue #96 migration. v0.7-beta stored the per-player NRage
 		 * analog-remap enable flag at gEnhancements.AnalogRemap.PX —

--- a/port/port.cpp
+++ b/port/port.cpp
@@ -413,6 +413,23 @@ static int PortInitImpl(int argc, char* argv[]) {
 		cv->SetFloat("gAdvancedResolution.AspectRatioY", 3.0f);
 		cv->SetInteger("gAdvancedResolution.Enabled", widescreen_on ? 0 : 1);
 
+		/* Latch gLowResMode at boot. libultraship's Gui::CalculateGameViewport
+		 * reads gLowResMode every frame and rewrites mCurDimensions, which
+		 * forces a Fast3D framebuffer reallocation. Doing that mid-session
+		 * races against the ImGui Metal backend: the per-frame ImGui::Image
+		 * cmd captures the old MTLTexture pointer at submit, but the FB
+		 * resource releases it on dim change before Metal's encoder retains
+		 * the texture, so the next setFragmentTexture: objc_retain hits a
+		 * freed object and SIGSEGVs (the same hazard documented above for
+		 * the widescreen toggle). The menu writes the user's choice to
+		 * gLowResModePending; we copy it here so LUS sees a constant
+		 * gLowResMode for the entire session and the FB resize only ever
+		 * happens at startup. */
+		if (cv->Get("gLowResModePending") == nullptr) {
+			cv->SetInteger("gLowResModePending", cv->GetInteger("gLowResMode", 0));
+		}
+		cv->SetInteger("gLowResMode", cv->GetInteger("gLowResModePending", 0));
+
 		/* Issue #96 migration. v0.7-beta stored the per-player NRage
 		 * analog-remap enable flag at gEnhancements.AnalogRemap.PX —
 		 * the same JSON path that PX.Deadzone / PX.Range hang off of.


### PR DESCRIPTION
## Summary

Exposes libultraship's existing low-resolution rendering paths through a new **Settings → Graphics → Low Resolution Mode** dropdown. Eight options grouped into two families:

- **Stretched** (`gLowResMode` 1–3): N64 320×240 4:3-centred, 240p / 480p window-aspect.
- **Pixel-perfect integer** (`gAdvancedResolution.PixelPerfectMode` + `VerticalResolutionToggle`): N64 320×240 drawn at integer factor — auto-fit, 2×, 3×, or 4×. Centred with black borders, no sub-pixel blur.

## Boot-latch hazard

Both LUS paths read their cvars every frame and rewrite `mCurDimensions`, which forces a Fast3D framebuffer reallocation. Toggling that mid-session races the ImGui Metal backend: the per-frame `ImGui::Image` cmd captures the old `MTLTexture` pointer at submit, the FB resource releases it on the dim change, and Metal's encoder `objc_retain`s a freed object → SIGSEGV in `setFragmentTexture:`. Same hazard the widescreen toggle is already latched against.

Mitigation: menu writes the user choice to `gLowResModePending`; `port.cpp`'s init block translates that into the appropriate combination of LUS cvars once per launch, so libultraship sees a stable state for the entire session. Tooltip + "(Needs reload)" suffix tell the user.

## Test plan

- [x] Clean build (`-j 4`).
- [x] Default (mode 0) — full-window rendering unchanged.
- [x] Mode 1 (stretched 4:3) — 320×240 FB stretched to fill height.
- [x] Modes 4–7 (pixel-perfect) — 320×240 FB integer-scaled, centred, sharp pixels.
- [x] Cross-launch persistence — value survives restart.
- [x] No mid-session crash when changing the dropdown (effect deferred to next launch).

🤖 Generated with [Claude Code](https://claude.com/claude-code)