### PR TITLE
Fix FB-passthrough wallpaper upside-down with MSAA > 1

### DIFF
--- a/port/bridge/framebuffer_capture.cpp
+++ b/port/bridge/framebuffer_capture.cpp
@@ -126,21 +126,29 @@ extern "C" int port_capture_register_fb_for_subrect(const void *base, unsigned i
         return -3;
     }
 
-    /* MSAA: mGameFb is multi-sampled and not directly sampleable as a normal
-     * texture. The interpreter resolves into mGameFbMsaaResolved at end-of-
-     * frame UNLESS the imgui game viewport matches the renderer resolution,
-     * in which case the resolve target is FB 0 (swap chain) instead and
-     * mGameFbMsaaResolved is left stale. We can't read FB 0 (post-Present),
-     * so bail in the matching-viewport MSAA case. */
-    int src_fb;
-    if (interp->mMsaaLevel > 1) {
-        if (interp->ViewportMatchesRendererResolution()) {
-            return -4;
-        }
-        src_fb = interp->mGameFbMsaaResolved;
-    } else {
-        src_fb = interp->mGameFb;
-    }
+    /* Always source from mGameFb. Two reasons:
+     *
+     * 1. mGameFb has opengl_invertY=true (Y-negated rendering matches the
+     *    snapshot FB's invertY=true). CopyFramebuffer therefore performs a
+     *    straight 1:1 row copy. If we sourced from mGameFbMsaaResolved
+     *    instead (created with opengl_invertY=false in the interpreter),
+     *    CopyFramebuffer's metadata mismatch would insert an unwanted Y-flip
+     *    during the blit, leaving the snapshot's storage row 0 holding
+     *    game-bottom instead of game-top — i.e. 1P stage-clear wallpaper
+     *    renders upside-down when MSAA > 1. (VS results photo wipe happens
+     *    to cancel that flip via its bottom-up mesh authoring.)
+     *
+     * 2. glBlitFramebuffer can read from an MSAA color buffer and resolve
+     *    into a single-sample destination in one call when dimensions match
+     *    (OpenGL spec: unscaled MSAA→non-MSAA blit performs an implicit
+     *    resolve). We don't need mGameFbMsaaResolved as a staging buffer.
+     *
+     * The legacy "ViewportMatchesRendererResolution + MSAA" bailout is also
+     * unnecessary now: that case was about mGameFbMsaaResolved being stale
+     * (resolve goes to FB 0 instead). mGameFb itself is always populated
+     * mid-frame, so it's a valid blit source regardless of viewport.
+     */
+    int src_fb = interp->mGameFb;
 
     int snap_fb = ensure_snapshot_fb(interp);
     if (snap_fb < 0) {


### PR DESCRIPTION
## Summary

- Root cause of "1P stage-clear wallpaper renders upside-down on Linux/OpenGL" turned out to be the MSAA path in `port_capture_register_fb_for_subrect`, not a GL_TEXTURE_2D sampling-direction quirk as commit 76cda34 had concluded.
- The bridge was sourcing the GPU→GPU blit from `mGameFbMsaaResolved` (which the interpreter creates with `opengl_invertY=false`), while the internal snapshot FB is `invertY=true`. `CopyFramebuffer`'s invertY-mismatch path applied an unwanted Y-swap during `glBlitFramebuffer`, leaving the snapshot's storage row 0 holding game-bottom instead of game-top.
- 1P (top-down `v0<v1` stripes) ended up upside-down on screen; VS results photo wipe (bottom-up `v0>v1` mesh) coincidentally cancelled the same flip and looked right-side-up. That's why "1P upside-down, VS rightside-up" was the consistent v0.9-beta+MSAA>1 report.

## Fix

Always source the blit from `mGameFb`:

- `mGameFb` is `invertY=true`, matching `snap_fb` → `CopyFramebuffer` does a clean 1:1 row copy.
- When MSAA > 1, `glBlitFramebuffer` performs the MSAA→non-MSAA resolve implicitly during an unscaled blit with matching dimensions (OpenGL spec). The previous two-step "resolve to `mGameFbMsaaResolved`, then blit" was unnecessary.
- The legacy `ViewportMatchesRendererResolution + MSAA` bailout (return -4) is also removed: that case existed because `mGameFbMsaaResolved` could be stale (end-of-frame resolve targets FB 0 instead). `mGameFb` itself is always populated mid-frame, so it's a valid blit source regardless of viewport.

## Why 76cda34's diagnosis missed this

The May 11 doc's truth table (`1P right-side-up + VS right-side-up = V-flip OFF correct`) was correct for **MSAA=1**, which is what the doc author tested. With MSAA>1 (the failing config every Linux/OpenGL user actually saw in v0.9-beta), the truth table doesn't apply because the asymmetry isn't in `FbNeedsSampleVFlip` — it's in `CopyFramebuffer`'s metadata-mismatch handling.

The 76cda34 commit is **not reverted** here. Its premise (V-flip OFF is correct on Linux/OpenGL) holds. This PR fixes the actual MSAA bug that was masking that correctness.

## Test plan

- [x] MSAA=1, 1P stage clear photo wallpaper renders right-side-up (unchanged)
- [x] MSAA=4, 1P stage clear photo wallpaper renders right-side-up (was upside-down)
- [x] MSAA=1, VS results photo wipe renders right-side-up (unchanged)
- [x] MSAA=4, VS results photo wipe renders right-side-up (was right-side-up by accident; now right-side-up for the right reason)
- [ ] Mac/Metal smoke test (Metal `CopyFramebuffer` has its own MSAA-source handling; the fix routes through `interp->mRapi->CopyFramebuffer` so it should be transparent, but worth a quick check)
- [ ] D3D11/Windows smoke test (same)

Tested locally on Linux/Fedora 43 + NVIDIA 595.58.03.

🤖 Generated with [Claude Code](https://claude.com/claude-code)