### PR TITLE
fix(jp): bifurcate JP into a fully separate application (name, app-data dir, ROM-locked)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -75,7 +75,7 @@ jobs:
           # NB: GHA `a && b || c` is not a ternary — an empty-string `b`
           # is falsy and falls through to `c`. Keep the non-empty value
           # in the `&&` branch and the empty default in `||`.
-          path: dist/BattleShip${{ matrix.version == 'jp' && '-jp' || '' }}.dmg
+          path: dist/BattleShip${{ matrix.version == 'jp' && '-JP' || '' }}.dmg
           if-no-files-found: error
 
   build-linux:
@@ -162,7 +162,7 @@ jobs:
       - uses: actions/upload-artifact@v4
         with:
           name: BattleShip-linux-${{ matrix.version }}
-          path: dist/BattleShip${{ matrix.version == 'jp' && '-jp' || '' }}-x86_64.AppImage
+          path: dist/BattleShip${{ matrix.version == 'jp' && '-JP' || '' }}-x86_64.AppImage
           if-no-files-found: error
 
   build-windows:
@@ -200,7 +200,7 @@ jobs:
       - uses: actions/upload-artifact@v4
         with:
           name: BattleShip-windows-${{ matrix.version }}
-          path: dist/BattleShip${{ matrix.version == 'jp' && '-jp' || '' }}-windows.zip
+          path: dist/BattleShip${{ matrix.version == 'jp' && '-JP' || '' }}-windows.zip
           if-no-files-found: error
 
   release:
@@ -218,11 +218,11 @@ jobs:
         with:
           files: |
             artifacts/BattleShip.dmg
-            artifacts/BattleShip-jp.dmg
+            artifacts/BattleShip-JP.dmg
             artifacts/BattleShip-x86_64.AppImage
-            artifacts/BattleShip-jp-x86_64.AppImage
+            artifacts/BattleShip-JP-x86_64.AppImage
             artifacts/BattleShip-windows.zip
-            artifacts/BattleShip-jp-windows.zip
+            artifacts/BattleShip-JP-windows.zip
           generate_release_notes: true
           draft: true   # land as a draft so a human can sanity-check
                         # before the release is visible to the public.

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -260,12 +260,29 @@ endif()
 #   src/libultra/ - Replaced by libultraship
 ################################################################################
 
+# User-facing application identity. The JP build is a SEPARATE application:
+# distinct binary name, distinct app-data dir (saves/config/logs/o2r), so a
+# user can have both installed and they never touch each other's ROM/o2r.
+# US keeps the historical "BattleShip" so existing installs / the in-app
+# updater / release links are unaffected. This single value drives the
+# binary OUTPUT_NAME, the libultraship Context name/shortName (which scopes
+# the app-data directory), and the per-platform package scripts.
+if(SSB64_VERSION STREQUAL "jp")
+    set(SSB64_APP_NAME "BattleShip-JP")
+else()
+    set(SSB64_APP_NAME "BattleShip")
+endif()
+message(STATUS "SSB64 app identity: ${SSB64_APP_NAME}")
+
 # Shared compile definitions used by both the decomp object library and the
 # main executable.
 set(SSB64_COMPILE_DEFS
     # Region (REGION_US/VERSION_US or REGION_JP/VERSION_JP per SSB64_VERSION)
     REGION_${SSB64_VERSION_UC}=1
     VERSION_${SSB64_VERSION_UC}=1
+    # App identity (binary name + libultraship app-data scope). Quoted so
+    # it expands to a C string literal at the use site.
+    SSB64_APP_NAME=\"${SSB64_APP_NAME}\"
 
     # Port mode
     NON_MATCHING=1
@@ -403,8 +420,9 @@ add_executable(${PROJECT_NAME} ${SSB64_SRC_PORT} ${SSB64_DEBUG_TOOLS} $<TARGET_O
 
 # User-facing binary name. The CMake target keeps the historical
 # `ssb64` identifier (matches the repo, build dirs, internal symbols),
-# but the produced executable is `BattleShip` / `BattleShip.exe`.
-set_target_properties(${PROJECT_NAME} PROPERTIES OUTPUT_NAME "BattleShip")
+# but the produced executable is `${SSB64_APP_NAME}` — `BattleShip`
+# (US) or `BattleShip-JP` (JP), so the two are distinct applications.
+set_target_properties(${PROJECT_NAME} PROPERTIES OUTPUT_NAME "${SSB64_APP_NAME}")
 
 if (CMAKE_SYSTEM_NAME STREQUAL "Windows")
     set_target_properties(ssb64_game PROPERTIES

--- a/port/first_run.cpp
+++ b/port/first_run.cpp
@@ -27,6 +27,22 @@
 
 namespace fs = std::filesystem;
 
+// Region the binary was compiled for (see CMake REGION_US/REGION_JP).
+// First-run asset extraction is region-locked: a JP build extracts only
+// from a JP ROM into the JP app-data dir, and never looks at a US ROM /
+// US o2r (and vice versa). US strings are kept verbatim so US behaviour
+// is byte-for-byte unchanged.
+#if defined(REGION_JP)
+static constexpr const char* kRegion  = "jp";
+static constexpr const char* kRomBase = "baserom.jp";
+static constexpr const char* kRomDesc = "Japanese (NALJ) \"Nintendo All-Star! "
+                                        "Dairantou Smash Brothers\" ROM";
+#else
+static constexpr const char* kRegion  = "us";
+static constexpr const char* kRomBase = "baserom.us";
+static constexpr const char* kRomDesc = "Super Smash Bros. NTSC-U v1.0 ROM";
+#endif
+
 namespace ssb64 {
 
 namespace {
@@ -241,7 +257,7 @@ std::string FindAssetConfigDir() {
     for (const auto& root : roots) {
         fs::path dir = root;
         while (!dir.empty()) {
-            if (fs::exists(dir / "config.yml") && fs::exists(dir / "yamls" / "us")) {
+            if (fs::exists(dir / "config.yml") && fs::exists(dir / "yamls" / kRegion)) {
                 return dir.string();
             }
 
@@ -262,7 +278,7 @@ std::string FindBaseRom() {
     std::vector<std::string> candidates;
     for (const auto& base : {appData, bundle, bundle + "/..", std::string(".")}) {
         for (const char* ext : {"z64", "n64", "v64"}) {
-            candidates.push_back(base + "/baserom.us." + ext);
+            candidates.push_back(base + "/" + kRomBase + "." + ext);
         }
     }
 
@@ -312,11 +328,11 @@ ExtractionResult ExtractAssetsIfNeeded(const std::string& target_o2r_path, bool 
     if (rom.empty()) {
         const std::string appData = Ship::Context::GetAppDirectoryPath();
         port_log("first_run: ERROR no ROM found.\n"
-                 "  Drop a baserom.us.{z64,n64,v64} into %s\n",
-                 appData.c_str());
+                 "  Drop a %s.{z64,n64,v64} into %s\n",
+                 kRomBase, appData.c_str());
         const std::string msg =
-            "Asset extraction needs your Super Smash Bros. NTSC-U v1.0 ROM.\n\n"
-            "Place a baserom.us.z64 (or .n64 / .v64) into:\n  " + appData +
+            "Asset extraction needs your " + std::string(kRomDesc) + ".\n\n"
+            "Place a " + std::string(kRomBase) + ".z64 (or .n64 / .v64) into:\n  " + appData +
             "\n\nThen launch the game again.";
         if (!silent) {
             SDL_ShowSimpleMessageBox(SDL_MESSAGEBOX_ERROR,
@@ -334,8 +350,8 @@ ExtractionResult ExtractAssetsIfNeeded(const std::string& target_o2r_path, bool 
 
     const std::string cfgDir = FindAssetConfigDir();
     if (cfgDir.empty()) {
-        port_log("first_run: ERROR could not locate config.yml + yamls/us/\n");
-        return { false, {}, "Could not locate config.yml + yamls/us", {} };
+        port_log("first_run: ERROR could not locate config.yml + yamls/%s/\n", kRegion);
+        return { false, {}, std::string("Could not locate config.yml + yamls/") + kRegion, {} };
     }
     port_log("first_run: asset config dir -> %s\n", cfgDir.c_str());
 
@@ -441,8 +457,8 @@ bool RunFirstRunWizard(const std::string& target_o2r_path) {
     // 256 char ImGui input buffer. Pre-fill with the conventional path the
     // user is most likely to try first; they can edit/replace freely.
     char romPath[1024] = {0};
-    std::snprintf(romPath, sizeof(romPath), "%s/baserom.us.z64",
-                  appData.c_str());
+    std::snprintf(romPath, sizeof(romPath), "%s/%s.z64",
+                  appData.c_str(), kRomBase);
 
     enum class State { WaitingForRom, Extracting, Done, Cancelled };
     State state = State::WaitingForRom;
@@ -531,8 +547,8 @@ bool RunFirstRunWizard(const std::string& target_o2r_path) {
                     "Nintendo 64 ROM before it can launch.");
                 ImGui::Spacing();
                 ImGui::TextWrapped(
-                    "Required: a Super Smash Bros. (NTSC-U v1.0) dump in "
-                    ".z64, .n64, or .v64 format.");
+                    "Required: a %s dump in .z64, .n64, or .v64 format.",
+                    kRomDesc);
                 ImGui::Separator();
 
                 ImGui::Text("ROM path:");

--- a/port/port.cpp
+++ b/port/port.cpp
@@ -380,9 +380,20 @@ static int PortInitImpl(int argc, char* argv[]) {
 		port_dl_ranges_init();
 	}
 
+	/* App identity comes from CMake (SSB64_APP_NAME = "BattleShip" for US,
+	 * "BattleShip-JP" for JP). The shortName scopes libultraship's
+	 * app-data directory (Context::GetAppDirectoryPath →
+	 * ~/Library/Application Support/<shortName>, $XDG_DATA_HOME/<shortName>,
+	 * %APPDATA%\<shortName>), so US and JP get fully separate
+	 * saves/config/logs/BattleShip.o2r and can never read each other's
+	 * ROM-derived data. The config filename stays fixed — it already
+	 * lives inside the per-app (bifurcated) directory. */
+#ifndef SSB64_APP_NAME
+#define SSB64_APP_NAME "BattleShip"
+#endif
 	sContext = Ship::Context::CreateUninitializedInstance(
-		"BattleShip",
-		"BattleShip",
+		SSB64_APP_NAME,
+		SSB64_APP_NAME,
 		"BattleShip.cfg.json"
 	);
 

--- a/scripts/package-linux.sh
+++ b/scripts/package-linux.sh
@@ -36,17 +36,19 @@
 set -euo pipefail
 
 ROOT="$(cd "$(dirname "$0")/.." && pwd)"
-# ROM version: us (default) or jp — each is its own region-compiled
-# binary; CI matrixes over both. US keeps the historical artifact name
-# so existing links / the in-app updater are unaffected; JP gets "-jp".
+# ROM version: us (default) or jp. The JP build is a SEPARATE
+# application — own binary name, AppImage, app-data dir — so a user can
+# keep both and they never touch each other's ROM/o2r/saves. APP_NAME
+# mirrors CMake SSB64_APP_NAME / OUTPUT_NAME. US keeps the historical
+# "BattleShip" identity so existing links / the in-app updater are
+# unaffected.
 VER="${SSB64_VERSION:-us}"
 [[ "$VER" == "us" || "$VER" == "jp" ]] || { echo "SSB64_VERSION must be us|jp" >&2; exit 1; }
-[[ "$VER" == "us" ]] && ART_SUFFIX="" || ART_SUFFIX="-$VER"
 BUILD_DIR="$ROOT/build-bundle-linux-$VER"
 DIST_DIR="$ROOT/dist"
-APPDIR="$DIST_DIR/BattleShip.AppDir"
-APP_NAME="BattleShip"
-APPIMAGE="$DIST_DIR/${APP_NAME}${ART_SUFFIX}-x86_64.AppImage"
+[[ "$VER" == "jp" ]] && APP_NAME="BattleShip-JP" || APP_NAME="BattleShip"
+APPDIR="$DIST_DIR/$APP_NAME.AppDir"
+APPIMAGE="$DIST_DIR/${APP_NAME}-x86_64.AppImage"
 JOBS="${JOBS:-$(nproc 2>/dev/null || echo 4)}"
 
 step() { printf '\n\033[36m=== %s ===\033[0m\n' "$1"; }
@@ -85,7 +87,7 @@ rm -f "$F3D_O2R"
 [[ -f "$F3D_O2R" ]] || fail "f3d.o2r was not created"
 
 # ── 3. Locate built artifacts ──
-GAME_BIN="$BUILD_DIR/BattleShip"
+GAME_BIN="$BUILD_DIR/$APP_NAME"   # CMake OUTPUT_NAME == SSB64_APP_NAME
 TORCH_BIN="$BUILD_DIR/TorchExternal/src/TorchExternal-build/torch"
 [[ -x "$GAME_BIN" ]] || fail "BattleShip binary not found at $GAME_BIN"
 [[ -x "$TORCH_BIN" ]] || fail "torch binary not found at $TORCH_BIN"
@@ -160,7 +162,7 @@ EOF
 cat > "$APPDIR/$APP_NAME.desktop" <<EOF
 [Desktop Entry]
 Type=Application
-Name=BattleShip
+Name=$APP_NAME
 Exec=$APP_NAME
 Icon=$APP_NAME
 Categories=Game;ArcadeGame;
@@ -278,5 +280,5 @@ else
     printf '   Install appimagetool from https://github.com/AppImage/AppImageKit/releases\n'
     printf '   then run: appimagetool "%s" "%s"\n' "$APPDIR" "$APPIMAGE"
 fi
-printf '   App-data: $XDG_DATA_HOME/BattleShip/ (or ~/.local/share/BattleShip/)\n'
+printf '   App-data: $XDG_DATA_HOME/%s/ (or ~/.local/share/%s/)\n' "$APP_NAME" "$APP_NAME"
 printf '   First launch will prompt for your ROM via the ImGui wizard.\n'

--- a/scripts/package-macos.sh
+++ b/scripts/package-macos.sh
@@ -30,16 +30,24 @@
 set -euo pipefail
 
 ROOT="$(cd "$(dirname "$0")/.." && pwd)"
-# ROM version to build: us (default) or jp. Each is its own
-# region-compiled binary; CI matrixes over both. US keeps the
-# historical artifact name (BattleShip.dmg) so existing links / the
-# in-app updater are unaffected; JP gets a "-jp" suffix.
+# ROM version: us (default) or jp. The JP build is a SEPARATE
+# application — its own binary name, .app, .dmg, app-data dir and
+# bundle id — so a user can keep both installed and they never touch
+# each other's ROM/o2r/saves. APP_NAME mirrors CMake SSB64_APP_NAME /
+# OUTPUT_NAME (BattleShip vs BattleShip-JP); the built binary is named
+# accordingly. US keeps the historical "BattleShip" identity so existing
+# installs / the in-app updater / release links are unaffected.
 VER="${SSB64_VERSION:-us}"
 [[ "$VER" == "us" || "$VER" == "jp" ]] || { echo "SSB64_VERSION must be us|jp" >&2; exit 1; }
-[[ "$VER" == "us" ]] && ART_SUFFIX="" || ART_SUFFIX="-$VER"
 BUILD_DIR="$ROOT/build-bundle-$VER"
 DIST_DIR="$ROOT/dist"
-APP_NAME="BattleShip"
+if [[ "$VER" == "jp" ]]; then
+    APP_NAME="BattleShip-JP"
+    APP_BUNDLE_ID="com.ssb-decomp-re.battleship-jp"
+else
+    APP_NAME="BattleShip"
+    APP_BUNDLE_ID="com.ssb-decomp-re.battleship"
+fi
 APP="$DIST_DIR/$APP_NAME.app"
 JOBS="${JOBS:-$(sysctl -n hw.ncpu 2>/dev/null || echo 4)}"
 
@@ -85,7 +93,9 @@ rm -f "$F3D_O2R"
 [[ -f "$F3D_O2R" ]] || fail "f3d.o2r was not created"
 
 # ── 2. Locate built artifacts ──
-SSB64_BIN="$BUILD_DIR/BattleShip"
+# CMake's OUTPUT_NAME == SSB64_APP_NAME == $APP_NAME, so the binary is
+# named BattleShip (US) or BattleShip-JP (JP).
+SSB64_BIN="$BUILD_DIR/$APP_NAME"
 TORCH_BIN="$BUILD_DIR/TorchExternal/src/TorchExternal-build/torch"
 [[ -x "$SSB64_BIN" ]] || fail "BattleShip binary not found at $SSB64_BIN"
 [[ -x "$TORCH_BIN" ]] || fail "torch binary not found at $TORCH_BIN"
@@ -163,9 +173,9 @@ cat > "$APP/Contents/Info.plist" <<EOF
   "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
-    <key>CFBundleName</key>                <string>BattleShip</string>
-    <key>CFBundleDisplayName</key>         <string>BattleShip</string>
-    <key>CFBundleIdentifier</key>          <string>com.ssb-decomp-re.battleship</string>
+    <key>CFBundleName</key>                <string>$APP_NAME</string>
+    <key>CFBundleDisplayName</key>         <string>$APP_NAME</string>
+    <key>CFBundleIdentifier</key>          <string>$APP_BUNDLE_ID</string>
     <key>CFBundleVersion</key>             <string>1.0</string>
     <key>CFBundleShortVersionString</key>  <string>1.0</string>
     <key>CFBundlePackageType</key>         <string>APPL</string>
@@ -298,10 +308,10 @@ codesign --verify --deep --strict "$APP" \
 # single multi-representation TIFF — Apple's documented mechanism for
 # resolution-independent DMG backgrounds; Finder picks the right rep
 # based on the user's display.
-DMG_VOLNAME="BattleShip"
+DMG_VOLNAME="$APP_NAME"
 DMG_BG_SRC="$ROOT/assets/macos_dmg_banner.png"
 DMG_BG_LONG=600
-DMG="$DIST_DIR/$APP_NAME$ART_SUFFIX.dmg"
+DMG="$DIST_DIR/$APP_NAME.dmg"
 DMG_STAGE="$DIST_DIR/dmg-stage"
 DMG_BG_DIR="$DIST_DIR/dmg-bg"
 
@@ -355,5 +365,5 @@ printf '\n\033[32m✓ Bundle: %s (%s KB)\033[0m\n' "$APP" "$APP_KB"
 printf '\033[32m✓ DMG:    %s (%s KB)\033[0m\n' "$DMG" "$DMG_KB"
 printf '   To run from the bundle:        open "%s"\n' "$APP"
 printf '   To install from the DMG:       open "%s"  (then drag to Applications)\n' "$DMG"
-printf '   App-data: ~/Library/Application Support/BattleShip/\n'
+printf '   App-data: ~/Library/Application Support/%s/\n' "$APP_NAME"
 printf '   First launch will prompt for your ROM via the ImGui wizard.\n'

--- a/scripts/package-windows.ps1
+++ b/scripts/package-windows.ps1
@@ -33,17 +33,19 @@
 $ErrorActionPreference = "Stop"
 
 $Root = Split-Path -Parent (Split-Path -Parent $MyInvocation.MyCommand.Path)
-# ROM version: us (default) or jp — each is its own region-compiled
-# binary; CI matrixes over both. US keeps the historical artifact name
-# so existing links / the in-app updater are unaffected; JP gets "-jp".
+# ROM version: us (default) or jp. The JP build is a SEPARATE
+# application — own .exe name, zip, app-data dir — so a user can keep
+# both and they never touch each other's ROM/o2r/saves. $AppName
+# mirrors CMake SSB64_APP_NAME / OUTPUT_NAME. US keeps the historical
+# "BattleShip" identity so existing links / the in-app updater are
+# unaffected.
 $Ver = if ($env:SSB64_VERSION) { $env:SSB64_VERSION } else { "us" }
 if ($Ver -ne "us" -and $Ver -ne "jp") { Write-Error "SSB64_VERSION must be us|jp"; exit 1 }
-$ArtSuffix = if ($Ver -eq "us") { "" } else { "-$Ver" }
 $BuildDir = Join-Path $Root "build-bundle-win-$Ver"
 $DistDir = Join-Path $Root "dist"
-$AppName = "BattleShip"
+$AppName = if ($Ver -eq "jp") { "BattleShip-JP" } else { "BattleShip" }
 $StageDir = Join-Path $DistDir $AppName
-$ZipPath = Join-Path $DistDir "$AppName$ArtSuffix-windows.zip"
+$ZipPath = Join-Path $DistDir "$AppName-windows.zip"
 $Jobs = if ($env:NUMBER_OF_PROCESSORS) { [int]$env:NUMBER_OF_PROCESSORS } else { 4 }
 
 function Write-Step($msg) { Write-Host "`n=== $msg ===" -ForegroundColor Cyan }
@@ -94,10 +96,12 @@ Pop-Location
 if (-not (Test-Path $F3DO2R)) { Fail "f3d.o2r was not created" }
 
 # ── 3. Locate built artifacts ──
-$GameExe = Join-Path $BuildDir "Release\BattleShip.exe"
+# CMake OUTPUT_NAME == SSB64_APP_NAME == $AppName, so the exe is
+# BattleShip.exe (US) or BattleShip-JP.exe (JP).
+$GameExe = Join-Path $BuildDir "Release\$AppName.exe"
 if (-not (Test-Path $GameExe)) {
     # Fall back to non-multi-config layout (Ninja).
-    $GameExe = Join-Path $BuildDir "BattleShip.exe"
+    $GameExe = Join-Path $BuildDir "$AppName.exe"
 }
 $TorchExe = $null
 foreach ($cand in @(
@@ -108,7 +112,7 @@ foreach ($cand in @(
     $p = Join-Path $BuildDir $cand
     if (Test-Path $p) { $TorchExe = $p; break }
 }
-if (-not (Test-Path $GameExe))   { Fail "BattleShip.exe not found at $GameExe" }
+if (-not (Test-Path $GameExe))   { Fail "$AppName.exe not found at $GameExe" }
 if (-not $TorchExe)              { Fail "torch.exe not found in $BuildDir" }
 
 # ── 4. Stage the release tree ──


### PR DESCRIPTION
Makes the JP build a **distinct application** so US and JP can be
installed side by side and never touch each other's ROM /
`BattleShip.o2r` / saves. This eliminates the crash where a JP binary
loaded a stale **US** `o2r` from the shared app-data dir and SIGSEGV'd
at launch.

## Core (region-gated — US byte-for-byte unchanged)
- **`CMakeLists.txt`** — single source of truth `SSB64_APP_NAME`
  (`BattleShip` US / `BattleShip-JP` JP) drives the binary `OUTPUT_NAME`
  and a quoted compile def.
- **`port/port.cpp`** — `SSB64_APP_NAME` becomes the libultraship
  `Context` name/shortName, which scopes the app-data directory. JP →
  `~/Library/Application Support/BattleShip-JP` (and the
  `$XDG_DATA_HOME` / `%APPDATA%` analogues): separate saves, config,
  logs, `o2r`.
- **`port/first_run.cpp`** — region-locked via `REGION_US/REGION_JP`:
  JP only discovers `baserom.jp.{z64,n64,v64}`, uses `yamls/jp`, and
  shows JP-appropriate wizard/error text. Never reads a US ROM.

## Packaging (identity rename keyed off region `APP_NAME`)
- `package-{macos,linux,windows}` → `BattleShip-JP.app`/`.dmg`,
  `BattleShip-JP-x86_64.AppImage`, `BattleShip-JP.exe` /
  `BattleShip-JP-windows.zip`, staging dirs, `.desktop`, icon, distinct
  macOS `CFBundleIdentifier` (`com.ssb-decomp-re.battleship-jp`).
  US artifact names unchanged → updater/links unaffected.
- `release.yml` — JP artifacts are `BattleShip-JP.*`.

## Local verification (macOS, no CI)
Built `dist/BattleShip-JP.app` + `.dmg`: Info.plist identity =
`BattleShip-JP` / `com.ssb-decomp-re.battleship-jp`, **LC_RPATH count =
1** (the v0.9.3 dyld duplicate-rpath fix still applies), **launches
cleanly**, uses the `BattleShip-JP` app-data dir, extracts the JP `o2r`
(10,249,960 B) from `baserom.jp`, and the US app-data/`o2r` is
untouched. US path unchanged by construction (all changes region-gated;
defaults are `BattleShip` / `baserom.us` with identical strings).

No submodule/decomp changes. Off `origin/main` (`a2f9d9d`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)