### PR TITLE
Hi-res texture pack support (US-only)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -312,6 +312,20 @@ if(SSB64_STAGE_CYCLE_DEMO)
     list(APPEND SSB64_COMPILE_DEFS PORT_STAGE_CYCLE_DEMO=1)
 endif()
 
+# Hi-res texture pack support is US-only. Pack PNGs are addressed by
+# CRC32-IEEE of the decoded RGBA8 buffer that came out of the US ROM
+# fast-path; JP rendering hits different hash inputs (different glyph
+# art for VS-records, JP-only menus, plus palette/sprite nuances on
+# shared assets), so a US-built pack would silently miss on JP and no
+# JP-only pack has been authored. Drop port/hires/ from the JP build
+# entirely and gate the port.cpp / PortMenu.cpp integration on
+# PORT_HIRES_ENABLED.
+if(SSB64_VERSION STREQUAL "us")
+    list(APPEND SSB64_COMPILE_DEFS PORT_HIRES_ENABLED=1)
+else()
+    list(FILTER SSB64_SRC_PORT EXCLUDE REGEX "port/hires/")
+endif()
+
 ################################################################################
 # Decomp C code — OBJECT library with custom include/ shadowing system headers
 ################################################################################

--- a/port/gui/PortMenu.cpp
+++ b/port/gui/PortMenu.cpp
@@ -9,6 +9,7 @@
 
 #include "Compat.h"
 #include "../enhancements/enhancements.h"
+#include "../hires/HiResPack.h"
 
 #include <fast/backends/gfx_rendering_api.h>
 #include <fast/postprocess/PostProcessSourceLoader.h>
@@ -1126,6 +1127,60 @@ void PortMenu::AddMenuAssets() {
     AddWidget(path, fmt::format("App directory: {}", Ship::Context::GetPathRelativeToAppDirectory("")), WIDGET_TEXT);
     AddWidget(path, fmt::format("Main archive: {}", Ship::Context::GetPathRelativeToAppDirectory("BattleShip.o2r")),
               WIDGET_TEXT);
+
+    path.sidebarName = "Mods";
+    path.column = SECTION_COLUMN_1;
+    AddSidebarEntry("Assets", "Mods", 1);
+
+    AddWidget(path, "Hi-Res Texture Pack", WIDGET_SEPARATOR_TEXT);
+    AddWidget(path,
+              "Drop a PNG pack into the mods/ folder. "
+              "Files are matched by decoded-RGBA8 CRC32 — no per-PNG configuration needed. "
+              "Toggle takes effect on the next texture cache miss.",
+              WIDGET_TEXT);
+    AddWidget(path, "Enable Hi-Res Texture Pack", WIDGET_CVAR_CHECKBOX)
+        .CVar("gHiResTextures.Enabled")
+        .RaceDisable(false)
+        .Options(CheckboxOptions().Tooltip("When on, every cache-miss texture upload hashes the decoded RGBA8 image "
+                                            "and substitutes a matching PNG from the mods/ index at the pack's higher "
+                                            "resolution.")
+                     .DefaultValue(true));
+    AddWidget(path, "Open Mods Folder", WIDGET_BUTTON)
+        .RaceDisable(false)
+        .Callback([](WidgetInfo&) {
+            std::string modsPath = Ship::Context::GetPathRelativeToAppDirectory("mods");
+            std::error_code ec;
+            fs::create_directories(modsPath, ec); // make it if it isn't there yet
+            SDL_OpenURL(std::string("file:///" + fs::absolute(modsPath).string()).c_str());
+        })
+        .Options(ButtonOptions().Tooltip("Opens the mods/ folder in your file browser. Drop pack subfolders here."));
+    AddWidget(path,
+              fmt::format("Indexed PNGs: {}",
+                           ssb64::hires::HiResPack::Get().Stats().indexedTextures),
+              WIDGET_TEXT);
+
+    AddWidget(path, "Pack Authoring", WIDGET_SEPARATOR_TEXT);
+    AddWidget(path,
+              "Dump Source Textures writes one .bin per unique texture into "
+              "<app>/hires_dump/. Used by the offline conversion tool to "
+              "re-name a third-party Rice-CRC pack into our hash. Leave off "
+              "in normal play.",
+              WIDGET_TEXT);
+    AddWidget(path, "Dump Source Textures", WIDGET_CVAR_CHECKBOX)
+        .CVar("gHiResTextures.DumpSource")
+        .RaceDisable(false)
+        .Options(CheckboxOptions().Tooltip("On: every cache-miss with no pack hit dumps the source bytes + dimensions "
+                                            "to <app>/hires_dump/. One file per unique texture per session.")
+                     .DefaultValue(false));
+    AddWidget(path, "Open Dump Folder", WIDGET_BUTTON)
+        .RaceDisable(false)
+        .Callback([](WidgetInfo&) {
+            std::string dumpPath = Ship::Context::GetPathRelativeToAppDirectory("hires_dump");
+            std::error_code ec;
+            fs::create_directories(dumpPath, ec);
+            SDL_OpenURL(std::string("file:///" + fs::absolute(dumpPath).string()).c_str());
+        })
+        .Options(ButtonOptions().Tooltip("Opens the hires_dump/ folder where source-texture dumps land."));
 }
 
 void PortMenu::AddMenuAbout() {

--- a/port/gui/PortMenu.cpp
+++ b/port/gui/PortMenu.cpp
@@ -1181,6 +1181,32 @@ void PortMenu::AddMenuAssets() {
             SDL_OpenURL(std::string("file:///" + fs::absolute(dumpPath).string()).c_str());
         })
         .Options(ButtonOptions().Tooltip("Opens the hires_dump/ folder where source-texture dumps land."));
+
+    AddWidget(path, "Miss Dump (native key)", WIDGET_SEPARATOR_TEXT);
+    AddWidget(path,
+              "On: every cache-miss with no pack hit writes a .bmp + .rgba into "
+              "<app>/hires_miss_dump/, named with the port's native lookup key "
+              "(miss#<hash>#<fmt>#<siz>_<w>x<h>). Rename the matching pack PNG to "
+              "\"<anything>#<hash>#<fmt>#<siz>_all.png\" and drop it in mods/ to "
+              "bind textures whose Rice CRC no dumper can reach (VS-records "
+              "digits, tiny UI glyphs). Captures a full playthrough by default.",
+              WIDGET_TEXT);
+    AddWidget(path, "Dump Unmatched (native key)", WIDGET_CVAR_CHECKBOX)
+        .CVar("gHiResTextures.DumpMissRgba")
+        .RaceDisable(false)
+        .Options(CheckboxOptions().Tooltip("On: each unique unmatched texture is written as a viewable .bmp plus the "
+                                            "raw .rgba the hash was computed over. The filename is the exact "
+                                            "<hash>#<fmt>#<siz> the pack scanner looks up.")
+                     .DefaultValue(false));
+    AddWidget(path, "Open Miss-Dump Folder", WIDGET_BUTTON)
+        .RaceDisable(false)
+        .Callback([](WidgetInfo&) {
+            std::string missPath = Ship::Context::GetPathRelativeToAppDirectory("hires_miss_dump");
+            std::error_code ec;
+            fs::create_directories(missPath, ec);
+            SDL_OpenURL(std::string("file:///" + fs::absolute(missPath).string()).c_str());
+        })
+        .Options(ButtonOptions().Tooltip("Opens the hires_miss_dump/ folder where native-key dumps land."));
 }
 
 void PortMenu::AddMenuAbout() {

--- a/port/gui/PortMenu.cpp
+++ b/port/gui/PortMenu.cpp
@@ -9,7 +9,9 @@
 
 #include "Compat.h"
 #include "../enhancements/enhancements.h"
+#ifdef PORT_HIRES_ENABLED
 #include "../hires/HiResPack.h"
+#endif
 
 #include <fast/backends/gfx_rendering_api.h>
 #include <fast/postprocess/PostProcessSourceLoader.h>
@@ -1128,6 +1130,7 @@ void PortMenu::AddMenuAssets() {
     AddWidget(path, fmt::format("Main archive: {}", Ship::Context::GetPathRelativeToAppDirectory("BattleShip.o2r")),
               WIDGET_TEXT);
 
+#ifdef PORT_HIRES_ENABLED
     path.sidebarName = "Mods";
     path.column = SECTION_COLUMN_1;
     AddSidebarEntry("Assets", "Mods", 1);
@@ -1207,6 +1210,7 @@ void PortMenu::AddMenuAssets() {
             SDL_OpenURL(std::string("file:///" + fs::absolute(missPath).string()).c_str());
         })
         .Options(ButtonOptions().Tooltip("Opens the hires_miss_dump/ folder where native-key dumps land."));
+#endif // PORT_HIRES_ENABLED
 }
 
 void PortMenu::AddMenuAbout() {

--- a/port/hires/HiResHook.cpp
+++ b/port/hires/HiResHook.cpp
@@ -1,0 +1,39 @@
+#include "HiResHook.h"
+
+#include "HiResPack.h"
+#include "../port_log.h"
+
+#include <libultraship/libultraship.h>
+#include <fast/interpreter.h>
+
+#include <cstdint>
+
+namespace {
+
+bool HiResHook(uint8_t fmt, uint8_t siz,
+               const uint8_t* rgba8, uint16_t width, uint16_t height,
+               const uint8_t** outBuf, uint16_t* outW, uint16_t* outH) {
+    // Master enable lives in a CVar so the menu toggle takes effect
+    // immediately (no relaunch). Defaults to on — Init() already logged
+    // whether the mods/ folder exists, so a flat "no PNGs to substitute"
+    // setup is silently a no-op.
+    if (CVarGetInteger("gHiResTextures.Enabled", 1) == 0) {
+        return false;
+    }
+
+    const ssb64::hires::DecodedTexture* dec =
+        ssb64::hires::HiResPack::Get().Lookup(fmt, siz, rgba8, width, height);
+    if (dec == nullptr) return false;
+
+    *outBuf = dec->rgba.data();
+    *outW = dec->w;
+    *outH = dec->h;
+    return true;
+}
+
+} // namespace
+
+extern "C" void ssb64_hires_register(void) {
+    gfx_register_hires_hook(&HiResHook);
+    port_log("HiResPack: hook registered with libultraship Fast3D\n");
+}

--- a/port/hires/HiResHook.cpp
+++ b/port/hires/HiResHook.cpp
@@ -9,18 +9,28 @@
 #include <cstdint>
 #include <cstdio>
 #include <filesystem>
+#include <string>
 #include <unordered_set>
+#include <vector>
 
 namespace {
 
-// Diagnostic: when gHiResTextures.DumpMissRgba is enabled, the first
-// ~64 unique cache misses get their decoded RGBA8 written to disk for
+// Diagnostic: when gHiResTextures.DumpMissRgba is enabled, each unique
+// cache miss (deduped by decoded-RGBA8 CRC) gets written to disk for
 // visual inspection. Each file is named with the runtime's computed
-// hash + format + dims, so they can be diffed against the GLideN64
-// dump corpus to identify what category of texture isn't matching
-// (e.g., 4-bit formats with subtle decoder differences, sub-tile
-// loads where dimensions don't agree, etc.).
-constexpr size_t kMaxMissDumps = 64;
+// native key (`miss#<CRC32-IEEE>#<fmt>#<siz>_<w>x<h>`) — the exact
+// `<hash>#<fmt>#<siz>` the pack scanner looks up, so a Reloaded PNG
+// renamed to that key (any prefix, optional `_suffix`) drops straight
+// into mods/ and binds with zero Rice/mupen involvement. Used to cover
+// the residual textures whose Rice CRC the GLideN64 algorithm can't
+// reach (tiny UI/HUD glyphs: VS records digits, etc.).
+//
+// The cap is a CVar (gHiResTextures.MissDumpCap, default 8192 — enough
+// to capture everything reachable in one playthrough) so you can run
+// straight through to the VS-records screen and collect every miss.
+// A 32-bit BMP is written alongside the raw .rgba so the vanilla glyph
+// can be eyeballed against the pack PNG to find its pair.
+constexpr size_t kDefaultMissDumpCap = 8192;
 std::unordered_set<uint32_t> gMissDumped;
 std::string gMissDumpDir;
 bool gMissDumpDirReady = false;
@@ -41,9 +51,50 @@ uint32_t MissDumpCrc32(const uint8_t* p, size_t n) {
     return crc ^ 0xFFFFFFFFu;
 }
 
+// Minimal self-contained 32-bit BI_RGB BMP (bottom-up, BGRA). No deps.
+// Viewers show it opaque (BI_RGB ignores alpha) which is exactly what we
+// want for identifying which glyph this is. Returns false on any I/O error.
+bool WriteBmp32(const std::string& path, const uint8_t* rgba8, uint32_t w, uint32_t h) {
+    const uint32_t pixels = w * h;
+    const uint32_t imgBytes = pixels * 4u;
+    const uint32_t fileBytes = 54u + imgBytes;
+    uint8_t hdr[54] = {0};
+    hdr[0] = 'B'; hdr[1] = 'M';
+    auto put32 = [](uint8_t* p, uint32_t v) {
+        p[0] = v & 0xFF; p[1] = (v >> 8) & 0xFF; p[2] = (v >> 16) & 0xFF; p[3] = (v >> 24) & 0xFF;
+    };
+    put32(hdr + 2, fileBytes);
+    put32(hdr + 10, 54);          // pixel-data offset
+    put32(hdr + 14, 40);          // BITMAPINFOHEADER size
+    put32(hdr + 18, w);
+    put32(hdr + 22, h);           // positive = bottom-up
+    hdr[26] = 1;                  // planes
+    hdr[28] = 32;                 // bpp
+    put32(hdr + 34, imgBytes);
+    FILE* f = std::fopen(path.c_str(), "wb");
+    if (!f) return false;
+    std::fwrite(hdr, 1, 54, f);
+    // BMP rows are bottom-up; convert RGBA -> BGRA per pixel.
+    std::vector<uint8_t> row(w * 4u);
+    for (int32_t y = (int32_t)h - 1; y >= 0; --y) {
+        const uint8_t* src = rgba8 + (size_t)y * w * 4u;
+        for (uint32_t x = 0; x < w; ++x) {
+            row[x * 4 + 0] = src[x * 4 + 2]; // B
+            row[x * 4 + 1] = src[x * 4 + 1]; // G
+            row[x * 4 + 2] = src[x * 4 + 0]; // R
+            row[x * 4 + 3] = src[x * 4 + 3]; // A
+        }
+        std::fwrite(row.data(), 1, row.size(), f);
+    }
+    std::fclose(f);
+    return true;
+}
+
 void MaybeDumpMiss(uint8_t fmt, uint8_t siz, const uint8_t* rgba8, uint16_t w, uint16_t h) {
     if (CVarGetInteger("gHiResTextures.DumpMissRgba", 0) == 0) return;
-    if (gMissDumped.size() >= kMaxMissDumps) return;
+    const size_t cap = (size_t)CVarGetInteger("gHiResTextures.MissDumpCap",
+                                              (int32_t)kDefaultMissDumpCap);
+    if (gMissDumped.size() >= cap) return;
 
     size_t bytes = (size_t)w * h * 4;
     uint32_t crc = MissDumpCrc32(rgba8, bytes);
@@ -55,17 +106,23 @@ void MaybeDumpMiss(uint8_t fmt, uint8_t siz, const uint8_t* rgba8, uint16_t w, u
         std::error_code ec;
         std::filesystem::create_directories(gMissDumpDir, ec);
         gMissDumpDirReady = true;
-        port_log("HiResPack: miss-dump active -> %s (cap=%zu)\n", gMissDumpDir.c_str(), kMaxMissDumps);
+        port_log("HiResPack: miss-dump active -> %s (cap=%zu)\n", gMissDumpDir.c_str(), cap);
     }
 
-    char namebuf[96];
-    std::snprintf(namebuf, sizeof(namebuf),
-                  "miss#%08X#%X#%X_%ux%u.rgba", crc, fmt, siz, (unsigned)w, (unsigned)h);
-    std::string path = gMissDumpDir + "/" + namebuf;
-    if (FILE* f = std::fopen(path.c_str(), "wb")) {
+    // Stem encodes the port's native lookup key verbatim:
+    //   miss#<CRC32-IEEE>#<fmt>#<siz>_<w>x<h>
+    // Rename the matching Reloaded hi-res PNG to "<anything>#<crc>#<fmt>#<siz>_all.png"
+    // (the prefix and _suffix are free-form) and drop it in mods/ to bind it.
+    char stem[96];
+    std::snprintf(stem, sizeof(stem),
+                  "miss#%08X#%X#%X_%ux%u", crc, fmt, siz, (unsigned)w, (unsigned)h);
+    std::string base = gMissDumpDir + "/" + stem;
+
+    if (FILE* f = std::fopen((base + ".rgba").c_str(), "wb")) {
         std::fwrite(rgba8, 1, bytes, f);
         std::fclose(f);
     }
+    WriteBmp32(base + ".bmp", rgba8, w, h);
 }
 
 bool HiResHook(uint8_t fmt, uint8_t siz,

--- a/port/hires/HiResHook.cpp
+++ b/port/hires/HiResHook.cpp
@@ -7,8 +7,66 @@
 #include <fast/interpreter.h>
 
 #include <cstdint>
+#include <cstdio>
+#include <filesystem>
+#include <unordered_set>
 
 namespace {
+
+// Diagnostic: when gHiResTextures.DumpMissRgba is enabled, the first
+// ~64 unique cache misses get their decoded RGBA8 written to disk for
+// visual inspection. Each file is named with the runtime's computed
+// hash + format + dims, so they can be diffed against the GLideN64
+// dump corpus to identify what category of texture isn't matching
+// (e.g., 4-bit formats with subtle decoder differences, sub-tile
+// loads where dimensions don't agree, etc.).
+constexpr size_t kMaxMissDumps = 64;
+std::unordered_set<uint32_t> gMissDumped;
+std::string gMissDumpDir;
+bool gMissDumpDirReady = false;
+
+uint32_t MissDumpCrc32(const uint8_t* p, size_t n) {
+    static uint32_t tbl[256];
+    static bool init = false;
+    if (!init) {
+        for (uint32_t i = 0; i < 256; i++) {
+            uint32_t c = i;
+            for (int j = 0; j < 8; j++) c = (c >> 1) ^ (0xEDB88320u & -(c & 1u));
+            tbl[i] = c;
+        }
+        init = true;
+    }
+    uint32_t crc = 0xFFFFFFFFu;
+    for (size_t i = 0; i < n; i++) crc = tbl[(crc ^ p[i]) & 0xFF] ^ (crc >> 8);
+    return crc ^ 0xFFFFFFFFu;
+}
+
+void MaybeDumpMiss(uint8_t fmt, uint8_t siz, const uint8_t* rgba8, uint16_t w, uint16_t h) {
+    if (CVarGetInteger("gHiResTextures.DumpMissRgba", 0) == 0) return;
+    if (gMissDumped.size() >= kMaxMissDumps) return;
+
+    size_t bytes = (size_t)w * h * 4;
+    uint32_t crc = MissDumpCrc32(rgba8, bytes);
+    if (!gMissDumped.insert(crc).second) return;
+
+    if (!gMissDumpDirReady) {
+        try { gMissDumpDir = Ship::Context::GetPathRelativeToAppDirectory("hires_miss_dump"); }
+        catch (...) { gMissDumpDir = "hires_miss_dump"; }
+        std::error_code ec;
+        std::filesystem::create_directories(gMissDumpDir, ec);
+        gMissDumpDirReady = true;
+        port_log("HiResPack: miss-dump active -> %s (cap=%zu)\n", gMissDumpDir.c_str(), kMaxMissDumps);
+    }
+
+    char namebuf[96];
+    std::snprintf(namebuf, sizeof(namebuf),
+                  "miss#%08X#%X#%X_%ux%u.rgba", crc, fmt, siz, (unsigned)w, (unsigned)h);
+    std::string path = gMissDumpDir + "/" + namebuf;
+    if (FILE* f = std::fopen(path.c_str(), "wb")) {
+        std::fwrite(rgba8, 1, bytes, f);
+        std::fclose(f);
+    }
+}
 
 bool HiResHook(uint8_t fmt, uint8_t siz,
                const uint8_t* rgba8, uint16_t width, uint16_t height,
@@ -23,7 +81,10 @@ bool HiResHook(uint8_t fmt, uint8_t siz,
 
     const ssb64::hires::DecodedTexture* dec =
         ssb64::hires::HiResPack::Get().Lookup(fmt, siz, rgba8, width, height);
-    if (dec == nullptr) return false;
+    if (dec == nullptr) {
+        MaybeDumpMiss(fmt, siz, rgba8, width, height);
+        return false;
+    }
 
     *outBuf = dec->rgba.data();
     *outW = dec->w;

--- a/port/hires/HiResHook.h
+++ b/port/hires/HiResHook.h
@@ -1,0 +1,19 @@
+#pragma once
+
+/* C-ABI bridge between libultraship's gfx_register_hires_hook() and the
+ * port-side HiResPack singleton. Implementation lives in HiResHook.cpp;
+ * registration happens once during PortInit. */
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/* Wire the hook into libultraship. Idempotent; subsequent calls overwrite
+ * the registered callback (last-call-wins). Safe to call any time after
+ * Ship::Context is alive — the hook itself is not invoked until the first
+ * texture cache miss after a frame begins. */
+void ssb64_hires_register(void);
+
+#ifdef __cplusplus
+}
+#endif

--- a/port/hires/HiResPack.cpp
+++ b/port/hires/HiResPack.cpp
@@ -1,0 +1,474 @@
+#include "HiResPack.h"
+
+#include "../port_log.h"
+
+#include <libultraship/libultraship.h>
+#include <ship/utils/filesystemtools/Directory.h>
+
+// stb_image's implementation lives in libultraship's stb_impl.c (see
+// libultraship/cmake/dependencies/common.cmake) — only include the header
+// here to pick up the function declarations.
+#include <stb_image.h>
+
+#include <algorithm>
+#include <cctype>
+#include <cstring>
+#include <cstdio>
+#include <filesystem>
+#include <list>
+#include <optional>
+#include <string>
+#include <string_view>
+#include <unordered_map>
+#include <unordered_set>
+#include <utility>
+
+namespace ssb64::hires {
+
+namespace {
+
+struct HashKeyHasher {
+    size_t operator()(const HashKey& k) const noexcept {
+        // FNV-1a over the four payload bytes of rgba8Crc is plenty — the
+        // CRC32 itself already approximates uniform distribution; folding
+        // (fmt|siz) avoids degenerate collisions when packs duplicate the
+        // same RGBA8 image across multiple N64 formats.
+        uint64_t h = 1469598103934665603ULL;
+        for (int i = 0; i < 4; i++) {
+            h ^= (k.rgba8Crc >> (i * 8)) & 0xFFu;
+            h *= 1099511628211ULL;
+        }
+        h ^= (uint64_t)k.fmt << 32;
+        h ^= (uint64_t)k.siz << 40;
+        h *= 1099511628211ULL;
+        return (size_t)h;
+    }
+};
+
+// Index of all parsed pack PNGs. Phase 3 reads it from Lookup().
+std::unordered_map<HashKey, std::string, HashKeyHasher> gIndex;
+
+std::string gModsRoot;
+
+// Per-process dedup so dump-mode writes each unique key at most once per
+// run. Protects the disk from being hammered when the same texture cycles
+// through the texture cache repeatedly.
+std::unordered_set<uint64_t> gDumpedKeys;
+std::string gDumpDir;
+bool gDumpDirReady = false;
+
+constexpr uint32_t kDumpMagic   = 0x44524853u; // 'SHRD' little-endian
+constexpr uint32_t kDumpVersion = 1u;
+struct DumpHeader {
+    uint32_t magic;       // 'SHRD'
+    uint32_t version;     // 1
+    uint32_t width;       // post-mask/clamp pixel width
+    uint32_t height;      // post-mask/clamp pixel height
+    uint32_t bpl;         // source row stride in bytes
+    uint32_t texelBytes;  // = bytesPerLine * height
+    uint32_t paletteBytes;
+    uint8_t  fmt;         // G_IM_FMT_*
+    uint8_t  siz;         // G_IM_SIZ_*
+    uint8_t  pad[6];
+};
+static_assert(sizeof(DumpHeader) == 36, "DumpHeader must be 36 bytes");
+
+uint64_t SourceDumpDedupId(uint8_t fmt, uint8_t siz, uint32_t texelCrc, uint32_t palCrc) noexcept {
+    return ((uint64_t)texelCrc) | ((uint64_t)palCrc << 32) ^ ((uint64_t)fmt << 8) ^ ((uint64_t)siz << 16);
+}
+
+// CRC32-IEEE 802.3 (poly 0xEDB88320) — public-domain table-driven impl.
+// Not Rice CRC32: that algorithm originated in GPL N64 plugins and is
+// license-incompatible with this codebase. Pack PNGs intended for this
+// port are named with this hash instead, produced offline by a separate
+// (unbundled, GPL) conversion tool that decodes each source-byte dump to
+// RGBA8 and computes the same plain CRC32-IEEE over the decoded pixels.
+struct Crc32Table {
+    uint32_t v[256];
+    constexpr Crc32Table() : v{} {
+        for (uint32_t i = 0; i < 256; i++) {
+            uint32_t c = i;
+            for (int j = 0; j < 8; j++) c = (c >> 1) ^ (0xEDB88320u & -(c & 1u));
+            v[i] = c;
+        }
+    }
+};
+const Crc32Table gCrcTbl;
+
+// Plain CRC32-IEEE over a flat byte run. Used for the decoded-RGBA8 hash
+// (post-decode, no row stride) and for hashing source bytes / palette
+// bytes in dump-source mode.
+uint32_t Crc32Bytes(const uint8_t* src, size_t bytes) noexcept {
+    if (src == nullptr || bytes == 0) return 0;
+    uint32_t crc = 0xFFFFFFFFu;
+    for (size_t i = 0; i < bytes; i++) {
+        crc = gCrcTbl.v[(crc ^ src[i]) & 0xFFu] ^ (crc >> 8);
+    }
+    return crc ^ 0xFFFFFFFFu;
+}
+
+// CRC32-IEEE over a row-strided source-byte image — kept for the
+// dump-source helper, which still records source bytes so the offline
+// conversion tool can pair Reloaded packs to our decoded-RGBA8 names.
+uint32_t SourceTexelCrc(const uint8_t* src, int width, int height,
+                        int size, int rowStride) noexcept {
+    if (src == nullptr || width <= 0 || height <= 0 || rowStride <= 0) return 0;
+    const int bytesPerLine = (width << size) >> 1;
+    if (bytesPerLine <= 0) return 0;
+
+    uint32_t crc = 0xFFFFFFFFu;
+    for (int y = 0; y < height; y++) {
+        const uint8_t* row = src + (size_t)y * rowStride;
+        for (int x = 0; x < bytesPerLine; x++) {
+            crc = gCrcTbl.v[(crc ^ row[x]) & 0xFFu] ^ (crc >> 8);
+        }
+    }
+    return crc ^ 0xFFFFFFFFu;
+}
+
+// Decoded-RGBA LRU. Insert always succeeds (the just-inserted entry is at
+// the tail and is exempt from eviction); eviction only fires on subsequent
+// Insert() calls, never during a single Lookup() — so the pointer returned
+// from Lookup() is guaranteed valid through the immediately-following
+// UploadTexture call.
+class LruCache {
+public:
+    using Node = std::pair<HashKey, DecodedTexture>;
+
+    explicit LruCache(size_t budgetBytes) : mBudget(budgetBytes) {}
+
+    const DecodedTexture* Get(const HashKey& k) {
+        auto it = mIndex.find(k);
+        if (it == mIndex.end()) return nullptr;
+        // Move the hit to MRU end.
+        mList.splice(mList.end(), mList, it->second);
+        return &it->second->second;
+    }
+
+    void Insert(const HashKey& k, DecodedTexture&& tex) {
+        // If the same key already lives in the cache, drop the older entry.
+        if (auto it = mIndex.find(k); it != mIndex.end()) {
+            mBytes -= it->second->second.rgba.size();
+            mList.erase(it->second);
+            mIndex.erase(it);
+        }
+        size_t addBytes = tex.rgba.size();
+        mList.emplace_back(k, std::move(tex));
+        mIndex[k] = std::prev(mList.end());
+        mBytes += addBytes;
+        // Evict from the LRU end (front) until back under budget. Never
+        // evict the tail — that's what we just inserted.
+        while (mBytes > mBudget && mList.size() > 1) {
+            auto& front = mList.front();
+            mBytes -= front.second.rgba.size();
+            mIndex.erase(front.first);
+            mList.pop_front();
+        }
+    }
+
+    size_t Bytes() const noexcept { return mBytes; }
+
+private:
+    std::list<Node> mList;
+    std::unordered_map<HashKey, std::list<Node>::iterator, HashKeyHasher> mIndex;
+    size_t mBytes = 0;
+    size_t mBudget;
+};
+
+constexpr size_t kDefaultLruBudget = 256u * 1024u * 1024u; // 256 MB
+LruCache gLru{ kDefaultLruBudget };
+
+bool IsHexDigit(char c) noexcept {
+    return (c >= '0' && c <= '9') || (c >= 'A' && c <= 'F') || (c >= 'a' && c <= 'f');
+}
+
+bool ParseHex32(std::string_view s, uint32_t* out) noexcept {
+    if (s.size() != 8) return false;
+    uint32_t v = 0;
+    for (char c : s) {
+        if (!IsHexDigit(c)) return false;
+        uint32_t d = (c <= '9') ? (c - '0') : ((c | 0x20) - 'a' + 10);
+        v = (v << 4) | d;
+    }
+    *out = v;
+    return true;
+}
+
+bool ParseSingleDigit(std::string_view s, uint8_t* out) noexcept {
+    if (s.size() != 1 || s[0] < '0' || s[0] > '9') return false;
+    *out = (uint8_t)(s[0] - '0');
+    return true;
+}
+
+/* Parse a hires-pack filename into a HashKey.
+ *
+ *   <prefix>#<rgba8CRC8>#<fmt>#<siz>[_<anything>].png
+ *
+ * Returns nullopt on grammar mismatch. We accept any prefix (including
+ * none) — the prefix is decorative.
+ *
+ * Examples that parse successfully:
+ *   "SMASH BROTHERS#A1B2C3D4#0#2_all.png"   RGBA16 (decoded RGBA8 hash)
+ *   "anything#cafe1234#3#0.png"             IA4 (no fmtTag suffix)
+ *   "anything#cafe1234#3#0_anything.png"    IA4 with arbitrary fmtTag
+ *
+ * The fmt+siz fields are kept in the filename as a sanity check / human-
+ * readable hint, but they're folded into the HashKey so two textures whose
+ * decoded RGBA8 happens to collide across formats stay distinct.
+ */
+std::optional<HashKey> ParseFilename(std::string_view filename) {
+    // Strip trailing ".png" (case-insensitive).
+    if (filename.size() < 5) return std::nullopt;
+    std::string_view ext = filename.substr(filename.size() - 4);
+    bool isPng = (ext.size() == 4)
+        && (ext[0] == '.')
+        && ((ext[1] | 0x20) == 'p')
+        && ((ext[2] | 0x20) == 'n')
+        && ((ext[3] | 0x20) == 'g');
+    if (!isPng) return std::nullopt;
+    std::string_view stem = filename.substr(0, filename.size() - 4);
+
+    // Optional trailing _<fmtTag>: strip everything from the rightmost '_'
+    // forward IF it sits after the last '#' (so we don't eat underscores
+    // inside the prefix).
+    size_t lastHash = stem.rfind('#');
+    size_t lastUnder = stem.rfind('_');
+    if (lastUnder != std::string_view::npos && (lastHash == std::string_view::npos || lastUnder > lastHash)) {
+        stem = stem.substr(0, lastUnder);
+    }
+
+    // Split the body on '#' from the right: <prefix>#<crc>#<fmt>#<siz>.
+    size_t h3 = stem.rfind('#');
+    if (h3 == std::string_view::npos) return std::nullopt;
+    size_t h2 = stem.rfind('#', h3 - 1);
+    if (h2 == std::string_view::npos) return std::nullopt;
+    size_t h1 = stem.rfind('#', h2 - 1);
+    if (h1 == std::string_view::npos) return std::nullopt;
+
+    std::string_view crcField = stem.substr(h1 + 1, h2 - h1 - 1);
+    std::string_view fmtField = stem.substr(h2 + 1, h3 - h2 - 1);
+    std::string_view sizField = stem.substr(h3 + 1);
+
+    HashKey key{};
+    if (!ParseHex32(crcField, &key.rgba8Crc)) return std::nullopt;
+    if (!ParseSingleDigit(fmtField, &key.fmt)) return std::nullopt;
+    if (!ParseSingleDigit(sizField, &key.siz)) return std::nullopt;
+
+    return key;
+}
+
+} // namespace
+
+HiResPack& HiResPack::Get() {
+    static HiResPack inst;
+    return inst;
+}
+
+const char* HiResPack::ModsRoot() const noexcept {
+    return gModsRoot.c_str();
+}
+
+bool HiResPack::Init() {
+    mStats = {};
+    gIndex.clear();
+
+    // Resolve <app-data>/mods alongside BattleShip.o2r and ssb64_save.bin.
+    // Same convention as port_save.cpp.
+    try {
+        gModsRoot = Ship::Context::GetPathRelativeToAppDirectory("mods");
+    } catch (...) {
+        gModsRoot.clear();
+        port_log("HiResPack: Ship::Context not ready; mods/ disabled\n");
+        return false;
+    }
+
+    if (!Directory::Exists(gModsRoot)) {
+        port_log("HiResPack: %s does not exist; create it and drop a pack inside to enable\n",
+                 gModsRoot.c_str());
+        return false;
+    }
+
+    auto files = Directory::ListFiles(gModsRoot); // recursive
+    std::sort(files.begin(), files.end()); // deterministic collision-winner
+
+    for (const std::string& path : files) {
+        mStats.scannedFiles++;
+
+        // Extract the basename for parsing.
+        size_t slash = path.find_last_of("/\\");
+        std::string_view name = (slash == std::string::npos)
+            ? std::string_view(path)
+            : std::string_view(path).substr(slash + 1);
+
+        // Cheap pre-filter: must end in .png.
+        if (name.size() < 5) continue;
+        std::string_view ext = name.substr(name.size() - 4);
+        if (ext.size() != 4 || ext[0] != '.'
+            || (ext[1] | 0x20) != 'p' || (ext[2] | 0x20) != 'n' || (ext[3] | 0x20) != 'g') {
+            continue;
+        }
+
+        auto key = ParseFilename(name);
+        if (!key) {
+            mStats.skippedFilenames++;
+            continue;
+        }
+
+        auto [it, inserted] = gIndex.try_emplace(*key, path);
+        if (!inserted) {
+            mStats.collisions++;
+            it->second = path; // last-scanned (alphabetically last) wins
+        } else {
+            mStats.indexedTextures++;
+        }
+    }
+
+    port_log("HiResPack: scanned %s — %zu files, %zu indexed, %zu unparsed PNGs, %zu hash collisions\n",
+             gModsRoot.c_str(),
+             mStats.scannedFiles, mStats.indexedTextures,
+             mStats.skippedFilenames, mStats.collisions);
+    return true;
+}
+
+const DecodedTexture* HiResPack::Lookup(uint8_t fmt, uint8_t siz,
+                                         const uint8_t* rgba8,
+                                         uint16_t width, uint16_t height) {
+    if (gIndex.empty() || rgba8 == nullptr || width == 0 || height == 0) return nullptr;
+
+    mLookupStats.lookups++;
+
+    HashKey key{};
+    key.fmt = fmt;
+    key.siz = siz;
+    key.rgba8Crc = Crc32Bytes(rgba8, (size_t)width * height * 4);
+
+    // Per-call diagnostic for the first 8 lookups — confirms the hook is
+    // firing and shows the exact keys being searched.
+    if (mLookupStats.lookups <= 8) {
+        port_log("HiResPack: lookup #%llu fmt=%u siz=%u w=%u h=%u "
+                 "key=%08X#%X#%X (idx=%zu)\n",
+                 (unsigned long long)mLookupStats.lookups,
+                 fmt, siz, width, height,
+                 key.rgba8Crc, key.fmt, key.siz,
+                 gIndex.size());
+    }
+    // Periodic log so the user can see coverage drift while playing — every
+    // 64 cache misses (a few seconds of typical gameplay).
+    if ((mLookupStats.lookups & 0x3F) == 0) {
+        double rate = mLookupStats.lookups
+            ? (100.0 * (double)mLookupStats.hits / (double)mLookupStats.lookups)
+            : 0.0;
+        port_log("HiResPack: %llu lookups, %llu hits (%.1f%%), %llu decode-fails, LRU=%zu MB\n",
+                 (unsigned long long)mLookupStats.lookups,
+                 (unsigned long long)mLookupStats.hits,
+                 rate,
+                 (unsigned long long)mLookupStats.decodeFails,
+                 gLru.Bytes() / (1024u * 1024u));
+    }
+
+    if (const DecodedTexture* hit = gLru.Get(key)) {
+        mLookupStats.hits++;
+        return hit;
+    }
+
+    auto it = gIndex.find(key);
+    if (it == gIndex.end()) {
+        return nullptr;
+    }
+
+    int w = 0, h = 0, ch = 0;
+    uint8_t* raw = stbi_load(it->second.c_str(), &w, &h, &ch, 4);
+    if (raw == nullptr || w <= 0 || h <= 0 || w > 65535 || h > 65535) {
+        if (raw) stbi_image_free(raw);
+        port_log("HiResPack: stbi_load failed for %s (%s)\n",
+                 it->second.c_str(), stbi_failure_reason() ? stbi_failure_reason() : "?");
+        // Drop the entry so we don't keep retrying every cache miss.
+        gIndex.erase(it);
+        mLookupStats.decodeFails++;
+        return nullptr;
+    }
+
+    DecodedTexture tex;
+    tex.w = (uint16_t)w;
+    tex.h = (uint16_t)h;
+    tex.rgba.assign(raw, raw + (size_t)w * h * 4);
+    stbi_image_free(raw);
+
+    gLru.Insert(key, std::move(tex));
+    mLookupStats.hits++;
+    return gLru.Get(key);
+}
+
+void HiResPack::MaybeDumpSource(uint8_t fmt, uint8_t siz,
+                                 const uint8_t* texels, uint16_t width, uint16_t height, uint32_t bpl,
+                                 const uint8_t* palette, uint32_t paletteBytes) {
+    // Cheap CVar check up front. The hook layer reads the same CVar for the
+    // master enable; reading it here keeps dump-on toggling responsive.
+    if (CVarGetInteger("gHiResTextures.DumpSource", 0) == 0) return;
+    if (texels == nullptr || width == 0 || height == 0 || bpl == 0) return;
+
+    const uint32_t texelCrc = SourceTexelCrc(texels, width, height, siz, (int)bpl);
+    const uint32_t palCrc = (palette != nullptr && paletteBytes > 0)
+                                ? Crc32Bytes(palette, paletteBytes)
+                                : 0;
+
+    uint64_t dedup = SourceDumpDedupId(fmt, siz, texelCrc, palCrc);
+    if (!gDumpedKeys.insert(dedup).second) return; // already dumped this run
+
+    if (!gDumpDirReady) {
+        try {
+            gDumpDir = Ship::Context::GetPathRelativeToAppDirectory("hires_dump");
+        } catch (...) { gDumpDir = "hires_dump"; }
+        std::error_code ec;
+        std::filesystem::create_directories(gDumpDir, ec);
+        gDumpDirReady = true;
+        port_log("HiResPack: dump-source mode active, writing to %s\n", gDumpDir.c_str());
+    }
+
+    // Filename includes source-byte CRC + (optionally) palette CRC so the
+    // offline conversion tool can pair each .bin with its Reloaded PNG by
+    // looking up Rice CRC of the dumped texel bytes.
+    char namebuf[96];
+    if (palCrc != 0 || paletteBytes > 0) {
+        std::snprintf(namebuf, sizeof(namebuf),
+                      "ssb64src#%08X#%X#%X#%08X.bin",
+                      texelCrc, fmt, siz, palCrc);
+    } else {
+        std::snprintf(namebuf, sizeof(namebuf),
+                      "ssb64src#%08X#%X#%X.bin",
+                      texelCrc, fmt, siz);
+    }
+
+    std::string path = gDumpDir + "/" + namebuf;
+    FILE* f = std::fopen(path.c_str(), "wb");
+    if (f == nullptr) {
+        port_log("HiResPack: dump-source open failed: %s\n", path.c_str());
+        return;
+    }
+
+    DumpHeader hdr{};
+    hdr.magic = kDumpMagic;
+    hdr.version = kDumpVersion;
+    hdr.width = width;
+    hdr.height = height;
+    hdr.bpl = bpl;
+    const uint32_t bytesPerLine = (uint32_t)((width << siz) >> 1);
+    hdr.texelBytes = bytesPerLine * height;
+    hdr.paletteBytes = paletteBytes;
+    hdr.fmt = fmt;
+    hdr.siz = siz;
+
+    std::fwrite(&hdr, sizeof(hdr), 1, f);
+    // Texel bytes — write only the active rows (bytesPerLine each, row-by-
+    // row at bpl stride). The conversion tool reads them as a contiguous
+    // bytesPerLine*height blob, no stride.
+    for (uint32_t y = 0; y < height; y++) {
+        std::fwrite(texels + (size_t)y * bpl, 1, bytesPerLine, f);
+    }
+    if (paletteBytes > 0 && palette != nullptr) {
+        std::fwrite(palette, 1, paletteBytes, f);
+    }
+    std::fclose(f);
+}
+
+} // namespace ssb64::hires

--- a/port/hires/HiResPack.cpp
+++ b/port/hires/HiResPack.cpp
@@ -175,7 +175,7 @@ private:
     size_t mBudget;
 };
 
-constexpr size_t kDefaultLruBudget = 256u * 1024u * 1024u; // 256 MB
+constexpr size_t kDefaultLruBudget = 512u * 1024u * 1024u; // 512 MB
 LruCache gLru{ kDefaultLruBudget };
 
 bool IsHexDigit(char c) noexcept {

--- a/port/hires/HiResPack.cpp
+++ b/port/hires/HiResPack.cpp
@@ -342,15 +342,17 @@ const DecodedTexture* HiResPack::Lookup(uint8_t fmt, uint8_t siz,
     key.siz = siz;
     key.rgba8Crc = Crc32Bytes(rgba8, (size_t)width * height * 4);
 
-    // Per-call diagnostic for the first 8 lookups — confirms the hook is
-    // firing and shows the exact keys being searched.
+    // Per-call diagnostic + hit/miss flag for the first 8 lookups — lets us
+    // confirm the hook is firing on real boots without spamming the log
+    // during normal play.
+    bool will_hit = gIndex.find(key) != gIndex.end();
     if (mLookupStats.lookups <= 8) {
         port_log("HiResPack: lookup #%llu fmt=%u siz=%u w=%u h=%u "
-                 "key=%08X#%X#%X (idx=%zu)\n",
+                 "key=%08X#%X#%X %s\n",
                  (unsigned long long)mLookupStats.lookups,
                  fmt, siz, width, height,
                  key.rgba8Crc, key.fmt, key.siz,
-                 gIndex.size());
+                 will_hit ? "HIT" : "miss");
     }
     // Periodic log so the user can see coverage drift while playing — every
     // 64 cache misses (a few seconds of typical gameplay).

--- a/port/hires/HiResPack.h
+++ b/port/hires/HiResPack.h
@@ -1,0 +1,125 @@
+#pragma once
+
+/* Hi-res texture pack registry.
+ *
+ * Scans <app-data>/mods/ recursively at startup for PNG files whose names
+ * follow the grammar:
+ *
+ *   <anything>#<rgba8CRC32>#<fmt>#<siz>[_<anything>].png
+ *
+ * The hash key is a CRC32-IEEE over the *decoded* RGBA8 image — the same
+ * tightly-packed pixel buffer the GPU receives at upload time. This makes
+ * the key independent of N64 source byte layout (Sprite/Bitmap/raw/CI all
+ * decode to the same RGBA8 and hash the same), so the runtime hook can
+ * sit downstream of every format-specific decoder and the offline pack-
+ * conversion tool can derive the same key by decoding each pack PNG.
+ *
+ * Each parsed entry is stored in an in-memory map keyed by
+ * (rgba8CRC, fmt, siz). PNG decoding is deferred to first lookup; Init()
+ * only builds the index.
+ *
+ * Pack folders work additively — drop multiple subfolders under mods/ and
+ * the union of their PNGs is indexed. If two PNGs hash-collide the later
+ * scan wins (alphabetical order).
+ */
+
+#include <cstdint>
+#include <cstddef>
+#include <vector>
+
+namespace ssb64::hires {
+
+struct DecodedTexture {
+    std::vector<uint8_t> rgba; // tightly packed RGBA8, w * h * 4 bytes
+    uint16_t w = 0;
+    uint16_t h = 0;
+};
+
+struct HashKey {
+    uint32_t rgba8Crc;
+    uint8_t fmt;
+    uint8_t siz;
+    uint8_t pad0 = 0, pad1 = 0;
+
+    bool operator==(const HashKey&) const noexcept = default;
+};
+
+struct PackStats {
+    size_t scannedFiles;     // every file under mods/, .png or not
+    size_t indexedTextures;  // PNGs whose names parsed successfully
+    size_t skippedFilenames; // PNGs that did not match the grammar
+    size_t collisions;       // duplicate hash keys (later scan wins)
+};
+
+struct LookupStats {
+    uint64_t lookups;     // every Lookup() call (one per cache miss)
+    uint64_t hits;        // resolved to a decoded RGBA8 buffer
+    uint64_t decodeFails; // index hit but stbi_load failed (entry now removed)
+};
+
+class HiResPack {
+public:
+    static HiResPack& Get();
+
+    /* Resolves <app-data>/mods/, walks every file recursively, parses each
+     * .png filename, and builds the in-memory index. Safe to call before
+     * Window/ResourceManager are up — only depends on Ship::Context being
+     * alive. Returns true if at least one mods/ subdirectory existed; the
+     * pack itself is allowed to be empty. */
+    bool Init();
+
+    /* Diagnostic snapshot of the last Init() pass. */
+    const PackStats& Stats() const noexcept { return mStats; }
+
+    /* Resolved absolute path to the scanned mods/ root, for logging /
+     * "Open mods folder" UI button. Empty before Init(). */
+    const char* ModsRoot() const noexcept;
+
+    /* Hash the decoded RGBA8 image (CRC32-IEEE over `width*height*4` bytes)
+     * and return a substitute decoded RGBA8 buffer if the pack contains a
+     * matching PNG. Decode of the pack PNG is lazy + memoized; a small LRU
+     * caps total decoded RAM at ~256 MB. The returned pointer is owned by
+     * the LRU and stays valid through the calling frame's UploadTexture
+     * (eviction only fires on subsequent Lookup() calls that miss the
+     * cache, never during this call). Returns nullptr on miss / decode
+     * failure.
+     *
+     * Format-independent and byte-layout-independent: the input buffer is
+     * the exact tightly-packed RGBA8 image the GPU is about to receive, so
+     * Sprite-fixup / Bitmap-fixup / raw / CI-with-palette paths all collapse
+     * to the same key for the same visible texture content.
+     */
+    const DecodedTexture* Lookup(uint8_t fmt, uint8_t siz,
+                                 const uint8_t* rgba8,
+                                 uint16_t width, uint16_t height);
+
+    /* Live counters since process start (or last ResetLookupStats). */
+    LookupStats LookupStatsSnapshot() const noexcept { return mLookupStats; }
+    void ResetLookupStats() noexcept { mLookupStats = {}; }
+
+    /* When enabled (gHiResTextures.DumpSource CVar), dumps the source N64
+     * byte run + dimensions + palette to a .bin file under
+     * <app-data>/hires_dump/. Used by the offline GPL pack conversion tool
+     * (see tools/hires-pack-convert/) to translate Reloaded Rice-CRC PNG
+     * names into our decoded-RGBA8-CRC names.
+     *
+     * NOTE: As of the post-decode hook refactor this function is currently
+     * unreachable from the runtime path (Lookup() runs after the decode and
+     * no longer has source bytes). The dump call site needs to be re-wired
+     * into a pre-decode hook in libultraship; until then dump-mode is
+     * dormant. The implementation is kept intact so that re-wire is a
+     * one-line change. */
+    void MaybeDumpSource(uint8_t fmt, uint8_t siz,
+                         const uint8_t* texels, uint16_t width, uint16_t height, uint32_t bpl,
+                         const uint8_t* palette, uint32_t paletteBytes);
+
+private:
+    HiResPack() = default;
+    HiResPack(const HiResPack&) = delete;
+    HiResPack& operator=(const HiResPack&) = delete;
+
+    PackStats mStats{};
+    LookupStats mLookupStats{};
+};
+
+} // namespace ssb64::hires

--- a/port/hires/HiResPack.h
+++ b/port/hires/HiResPack.h
@@ -100,15 +100,11 @@ public:
     /* When enabled (gHiResTextures.DumpSource CVar), dumps the source N64
      * byte run + dimensions + palette to a .bin file under
      * <app-data>/hires_dump/. Used by the offline GPL pack conversion tool
-     * (see tools/hires-pack-convert/) to translate Reloaded Rice-CRC PNG
-     * names into our decoded-RGBA8-CRC names.
+     * (see tools/hires-pack-convert/convert.py).
      *
-     * NOTE: As of the post-decode hook refactor this function is currently
-     * unreachable from the runtime path (Lookup() runs after the decode and
-     * no longer has source bytes). The dump call site needs to be re-wired
-     * into a pre-decode hook in libultraship; until then dump-mode is
-     * dormant. The implementation is kept intact so that re-wire is a
-     * one-line change. */
+     * NOTE: dormant since the post-decode hook refactor — Lookup() no
+     * longer has source bytes. Kept available for a future re-wire into a
+     * pre-decode dump hook on the libultraship side. */
     void MaybeDumpSource(uint8_t fmt, uint8_t siz,
                          const uint8_t* texels, uint16_t width, uint16_t height, uint32_t bpl,
                          const uint8_t* palette, uint32_t paletteBytes);

--- a/port/port.cpp
+++ b/port/port.cpp
@@ -26,6 +26,8 @@
 #include "enhancements/enhancements.h"
 #include "first_run.h"
 #include "gui/PortMenu.h"
+#include "hires/HiResHook.h"
+#include "hires/HiResPack.h"
 #include "renderdoc_trigger.h"
 #include "port_log.h"
 
@@ -410,6 +412,13 @@ static int PortInitImpl(int argc, char* argv[]) {
 	if (!sContext->InitConfiguration()) { port_log("SSB64: InitConfiguration failed\n"); return 1; }
 	if (!sContext->InitConsoleVariables()) { port_log("SSB64: InitConsoleVariables failed\n"); return 1; }
 	port_log("SSB64: Config + CVars OK\n");
+
+	// Hi-res texture pack: scan <app-data>/mods/ for GLideN64-named PNGs
+	// and register the Fast3D substitution hook. Master enable lives in
+	// the gHiResTextures.Enabled CVar (default 1) — toggled from the
+	// Assets → Mods menu, takes effect next cache miss.
+	ssb64::hires::HiResPack::Get().Init();
+	ssb64_hires_register();
 
 	/* Pillarbox the framebuffer to 4:3 every launch. The game emits 4:3
 	 * GBI only — when LUS's viewport runs at the window aspect (LUS

--- a/port/port.cpp
+++ b/port/port.cpp
@@ -26,8 +26,10 @@
 #include "enhancements/enhancements.h"
 #include "first_run.h"
 #include "gui/PortMenu.h"
+#ifdef PORT_HIRES_ENABLED
 #include "hires/HiResHook.h"
 #include "hires/HiResPack.h"
+#endif
 #include "renderdoc_trigger.h"
 #include "port_log.h"
 
@@ -413,12 +415,15 @@ static int PortInitImpl(int argc, char* argv[]) {
 	if (!sContext->InitConsoleVariables()) { port_log("SSB64: InitConsoleVariables failed\n"); return 1; }
 	port_log("SSB64: Config + CVars OK\n");
 
+#ifdef PORT_HIRES_ENABLED
 	// Hi-res texture pack: scan <app-data>/mods/ for GLideN64-named PNGs
 	// and register the Fast3D substitution hook. Master enable lives in
 	// the gHiResTextures.Enabled CVar (default 1) — toggled from the
-	// Assets → Mods menu, takes effect next cache miss.
+	// Assets → Mods menu, takes effect next cache miss. US-only (see
+	// CMakeLists.txt — JP builds drop port/hires/ entirely).
 	ssb64::hires::HiResPack::Get().Init();
 	ssb64_hires_register();
+#endif
 
 	/* Pillarbox the framebuffer to 4:3 every launch. The game emits 4:3
 	 * GBI only — when LUS's viewport runs at the window aspect (LUS


### PR DESCRIPTION
Forward-port of the hi-res texture pack runtime onto current `main`, gated US-only.

## What this adds

Opt-in PNG substitution for Fast3D textures. At every cache miss the runtime hashes the decoded RGBA8 buffer with CRC32-IEEE and looks up the result in `<app-data>/mods/<pack>/`. Pack PNGs named `<anything>#<rgba8CRC8>#<fmt>#<siz>[_<tag>].png` are decoded via `stb_image` and uploaded at the pack's higher resolution in place of the N64 decode.

Components:
- `port/hires/HiResPack.{h,cpp}` — filename scan, FNV-keyed index, lazy `stb_image` decode, 512 MB LRU cache, source-byte dump mode.
- `port/hires/HiResHook.{h,cpp}` — C-ABI bridge to libultraship's `gfx_register_hires_hook`, plus native-key miss-dump (BMP + RGBA) for pack authoring against UI/HUD glyphs no Rice-CRC pipeline can reach.
- `port/port.cpp` — register the hook once after `Ship::Context` init.
- `port/gui/PortMenu.cpp` — Assets → Mods sidebar (Enable, Open Mods, Pack Authoring dump toggle, Miss Dump native-key toggle).

## US-only gate

Pack PNGs are addressed by CRC32-IEEE of the decoded RGBA8 from the US ROM fast-path; JP rendering hits different hash inputs (different VS-records glyph art, JP-only menus, palette/sprite nuances on shared assets). A US-built pack would silently miss on JP and no JP-only pack has been authored.

Gate lives at three layers (all keyed on `PORT_HIRES_ENABLED`):
1. **CMake** — `if(SSB64_VERSION STREQUAL "us")` appends `PORT_HIRES_ENABLED=1` to the shared compile-defs; the `else` branch does `list(FILTER SSB64_SRC_PORT EXCLUDE REGEX "port/hires/")` so the JP build never sees the translation units.
2. **`port.cpp`** — `#ifdef PORT_HIRES_ENABLED` around the two hires headers + the `HiResPack::Get().Init()` + `ssb64_hires_register()` calls in `PortInitImpl`.
3. **`PortMenu.cpp`** — `#ifdef PORT_HIRES_ENABLED` around the `HiResPack.h` include + the entire "Mods" sidebar.

JP build has zero references to `hires/`, `HiResPack`, `HiResHook`, or `ssb64_hires_register` after preprocessing; the LUS-side `gfx_register_hires_hook` symbol still exists in `libultraship` (always-on library) but sits with `Fast::gHiResHook` NULL — a safe noop.

## Build verification

| Check | US | JP |
|-------|-----|-----|
| Build exit | 0 ✅ | 0 ✅ |
| Binary | `BattleShip` 158 MB Debug | `BattleShip-JP` 157 MB Debug |
| Port-side `ssb64::hires::*` symbols | Present | **Absent** |
| Port-side C-ABI `ssb64_hires_register` | Present | **Absent** |
| LUS hook `gfx_register_hires_hook` | Present, registered | Present, NULL (noop) |
| Hires UI strings in binary | Present | **None** |
| New compiler warnings | None | None |

Size delta (~1.27 MB) matches the gated code footprint.

## Anatomy

Five commits — four cherry-picks from the original work + one gate commit:
- `2803863` Hi-res texture pack support — runtime hook + filename index
- `49148c2` HiResPack: log per-lookup hit/miss for the first 8 cache misses
- `9d26ed8` HiResPack: 512 MB LRU + CVar-gated miss-dump diagnostic
- `0c87f4e` HiResPack: native-key miss-dump for manual pack coverage
- `487bfcc` gate(hires): restrict hi-res texture pack to US builds

The libultraship submodule pointer is unchanged from `main` — the original branch's LUS bump was discarded because `main`'s current LUS SHA already contains the hires-pack hook (`gfx_register_hires_hook` at `src/fast/interpreter.cpp:7191`) as a descendant of that commit.

## Re-enabling for JP later

One-liner in `CMakeLists.txt` to drop the `if(SSB64_VERSION STREQUAL "us")` gate, plus authoring a JP-decoded pack (or running the in-app native-key miss-dump on a JP playthrough to bootstrap one).

🤖 Generated with [Claude Code](https://claude.com/claude-code)