### PR TITLE
Add Competitive Ruleset and other QoL features

### DIFF
--- a/port/enhancements/BootToVSCSS.cpp
+++ b/port/enhancements/BootToVSCSS.cpp
@@ -1,0 +1,16 @@
+#include "enhancements.h"
+#include <libultraship/bridge/consolevariablebridge.h>
+
+namespace ssb64 {
+    namespace enhancements {
+
+        const char* BootToVSCSSCVarName() {
+            return "gEnhancements.BootToVSCSS";
+        }
+
+    } // namespace enhancements
+} // namespace ssb64
+
+extern "C" int port_enhancement_boot_to_vs_css(void) {
+    return CVarGetInteger(ssb64::enhancements::BootToVSCSSCVarName(), 0) != 0;
+}

--- a/port/enhancements/CompRuleset.cpp
+++ b/port/enhancements/CompRuleset.cpp
@@ -1,0 +1,18 @@
+#include "enhancements.h"
+#include <libultraship/bridge/consolevariablebridge.h>
+
+namespace ssb64 {
+    namespace enhancements {
+
+        const char* CompRulesetCVarName() {
+            return "gEnhancements.CompRuleset";
+        }
+
+    } // namespace enhancements
+} // namespace ssb64
+
+extern "C" int port_get_comp_ruleset(void) {
+    // Reads the CVar from the UI bridge.
+    // The != 0 ensures it strictly returns a 1 or 0 boolean state for the C engine.
+    return CVarGetInteger(ssb64::enhancements::CompRulesetCVarName(), 0) != 0;
+}

--- a/port/enhancements/CpuLevel9.cpp
+++ b/port/enhancements/CpuLevel9.cpp
@@ -1,0 +1,16 @@
+#include "enhancements.h"
+#include <libultraship/bridge/consolevariablebridge.h>
+
+namespace ssb64 {
+    namespace enhancements {
+
+        const char* CpuLevel9CVarName() {
+            return "gEnhancements.CpuLevel9";
+        }
+
+    } // namespace enhancements
+} // namespace ssb64
+
+extern "C" int port_enhancement_cpu_level_9(void) {
+    return CVarGetInteger(ssb64::enhancements::CpuLevel9CVarName(), 0) != 0;
+}

--- a/port/enhancements/NeutralSpawns.cpp
+++ b/port/enhancements/NeutralSpawns.cpp
@@ -1,0 +1,16 @@
+#include "enhancements.h"
+#include <libultraship/bridge/consolevariablebridge.h>
+
+namespace ssb64 {
+    namespace enhancements {
+
+        const char* NeutralSpawnsCVarName() {
+            return "gEnhancements.NeutralSpawns";
+        }
+
+    } // namespace enhancements
+} // namespace ssb64
+
+extern "C" int port_enhancement_neutral_spawns(void) {
+    return CVarGetInteger(ssb64::enhancements::NeutralSpawnsCVarName(), 0) != 0;
+}

--- a/port/enhancements/SkipResultsScreen.cpp
+++ b/port/enhancements/SkipResultsScreen.cpp
@@ -1,0 +1,16 @@
+#include "enhancements.h"
+#include <libultraship/bridge/consolevariablebridge.h>
+
+namespace ssb64 {
+    namespace enhancements {
+
+        const char* SkipResultsScreenCVarName() {
+            return "gEnhancements.SkipResultsScreen";
+        }
+
+    } // namespace enhancements
+} // namespace ssb64
+
+extern "C" int port_enhancement_skip_results_screen(void) {
+    return CVarGetInteger(ssb64::enhancements::SkipResultsScreenCVarName(), 0) != 0;
+}

--- a/port/enhancements/enhancements.h
+++ b/port/enhancements/enhancements.h
@@ -48,6 +48,24 @@ void port_enhancement_analog_remap(int player_index, signed char* stick_x, signe
 
 int port_cheat_unlock_all_active(void);
 
+// competitive ruleset enhancements
+int port_get_comp_ruleset(void);
+void port_apply_comp_ruleset_overrides(void);
+void port_cleanup_comp_ruleset(void);
+void port_comp_ruleset_skip_stageselect(void);
+
+// neutral spawn points on dreamland
+int port_enhancement_neutral_spawns(void);
+
+// boot to CSS
+int port_enhancement_boot_to_vs_css(void);
+
+// skip results screen
+int port_enhancement_skip_results_screen(void);
+
+// cpu behavior
+int port_enhancement_cpu_level_9(void);
+
 #ifdef __cplusplus
 }
 
@@ -62,6 +80,11 @@ const char* AnalogRemapCVarName(int playerIndex);
 const char* AnalogRemapDeadzoneCVarName(int playerIndex);
 const char* AnalogRemapRangeCVarName(int playerIndex);
 const char* WidescreenCVarName();
+const char* CompRulesetCVarName();
+const char* NeutralSpawnsCVarName();
+const char* BootToVSCSSCVarName();
+const char* SkipResultsScreenCVarName();
+const char* CpuLevel9CVarName();
 
 // Updater functions
 void CheckForUpdatesAsync(bool force = false);

--- a/port/gui/PortMenu.cpp
+++ b/port/gui/PortMenu.cpp
@@ -981,6 +981,37 @@ void PortMenu::AddMenuSettings() {
                      .ComboMap(kHitboxViewMap)
                      .DefaultIndex(0));
 
+    // competitive ruleset stuff
+    AddWidget(path, "Rules", WIDGET_SEPARATOR_TEXT);
+    AddWidget(path, "Use Competitive Ruleset", WIDGET_CVAR_CHECKBOX)
+        .CVar(ssb64::enhancements::CompRulesetCVarName())
+        .RaceDisable(false)
+        .Options(CheckboxOptions().Tooltip("Forces the following in VS Mode: \n"
+                                           "- 4 Stocks \n"
+                                           "- 8 Minutes \n"
+                                           "- Items Off \n"
+                                           "- Team Attack ON \n"
+                                           "- Dream Land only"));
+    AddWidget(path, "Neutral Spawns on Dreamland", WIDGET_CVAR_CHECKBOX)
+        .CVar(ssb64::enhancements::NeutralSpawnsCVarName())
+        .RaceDisable(false)
+        .Options(CheckboxOptions().Tooltip("Forces balanced, opposite-side starting positions for 1v1 and Team Battles."));
+
+    // QoL
+    AddWidget(path, "Quality-of-Life", WIDGET_SEPARATOR_TEXT);
+    AddWidget(path, "Boot to VS CSS", WIDGET_CVAR_CHECKBOX)
+        .CVar(ssb64::enhancements::BootToVSCSSCVarName())
+        .RaceDisable(false)
+        .Options(CheckboxOptions().Tooltip("Skips the intro sequences and boots directly to the VS Mode Character Select Screen."));
+    AddWidget(path, "Skip Results Screen", WIDGET_CVAR_CHECKBOX)
+        .CVar(ssb64::enhancements::SkipResultsScreenCVarName())
+        .RaceDisable(false)
+        .Options(CheckboxOptions().Tooltip("Skips the victory podium and returns directly to the Character Select Screen."));
+    AddWidget(path, "Force CPU Level 9", WIDGET_CVAR_CHECKBOX)
+        .CVar(ssb64::enhancements::CpuLevel9CVarName())
+        .RaceDisable(false)
+        .Options(CheckboxOptions().Tooltip("Automatically forces all CPU players to Level 9."));
+
     // --- Controls sidebar: per-player input remapping ---
     path.sidebarName = "Controls";
     path.column = SECTION_COLUMN_1;


### PR DESCRIPTION
<img width="1575" height="1204" alt="Screenshot_20260522_123336" src="https://github.com/user-attachments/assets/412d6c49-6fa9-4fce-8b31-061b8b8a286d" />

Adds a **Competitive Ruleset** option in the *Settings -> Gameplay* menu. It will force the following:
- set to 4 stocks
- timer set to 8 minutes
- items disabled
- set Team Attack to ON
- skips the Stage Selection Screen in the VS mode and go straight to Dreamland

**perfessional gangster** from the Discord also asked to have neutral spawn points. After having a discussion with them, they wanted this as a separate toggle underneath the Competitive Ruleset checkbox. This will set the spawn points as follows on Dreamland:
- 1v1: P1 on the left platform, P2 on the right
- 2v2: One player is on the left platform, with their teammate directly below them. The opposing team is on the right platform, with their teammate underneath them as well

As I was working on this feature, I also wanted to quickly get right into the CSS to reduce downtime while testing. As such, I've added the following checkboxes:
- boot directly to the VS CSS
- skip the results/no contest screen
- force the CPU level to 9

Since I had to make changes to the `decomp` submodule, I've made that a separate PR here: https://github.com/JRickey/ssb-decomp-re/pull/5