### PR TITLE
ESC Menu Revamp (rebased from #170)

### DIFF
--- a/port/gui/PortMenu.cpp
+++ b/port/gui/PortMenu.cpp
@@ -981,6 +981,19 @@ void PortMenu::AddMenuSettings() {
                      .ComboMap(kHitboxViewMap)
                      .DefaultIndex(0));
 
+    // --- Input customization ---
+    path.sidebarName = "Input";
+    path.column = SECTION_COLUMN_1;
+    AddSidebarEntry("Settings", "Input", 1);
+
+    AddWidget(path, "Controller", WIDGET_SEPARATOR_TEXT);
+    AddWidget(path, "Controller Configuration", WIDGET_WINDOW_BUTTON)
+        .CVar(CVAR_CONTROLLER_CONFIGURATION_WINDOW_OPEN)
+        .RaceDisable(false)
+        .WindowName("Input Editor")
+        .HideInSearch(true)
+        .Options(WindowButtonOptions().Tooltip("Toggles the controller configuration window."));
+
     // --- Controls sidebar: per-player input remapping ---
     path.sidebarName = "Controls";
     path.column = SECTION_COLUMN_1;
@@ -1054,8 +1067,8 @@ void PortMenu::AddMenuSettings() {
 
     AddWidget(path, "Master Unlocks", WIDGET_SEPARATOR_TEXT);
     AddWidget(path, "Unlock Everything", WIDGET_CVAR_CHECKBOX)
-    .CVar("gCheats.UnlockAll")
-    .RaceDisable(false);
+        .CVar("gCheats.UnlockAll")
+        .RaceDisable(false);
 
     AddWidget(path, "Individual Characters", WIDGET_SEPARATOR_TEXT);
     AddWidget(path, "Unlock Captain Falcon", WIDGET_CVAR_CHECKBOX).CVar("gCheats.UnlockCaptain").RaceDisable(false);
@@ -1067,8 +1080,34 @@ void PortMenu::AddMenuSettings() {
     AddWidget(path, "Unlock Mushroom Kingdom", WIDGET_CVAR_CHECKBOX).CVar("gCheats.UnlockInishie").RaceDisable(false);
     AddWidget(path, "Unlock Item Switch Menu", WIDGET_CVAR_CHECKBOX).CVar("gCheats.UnlockItemSwitch").RaceDisable(false);
     AddWidget(path, "Unlock Sound Test Menu", WIDGET_CVAR_CHECKBOX).CVar("gCheats.UnlockSoundTest").RaceDisable(false);
+
+    // --- Tools ---
+    path.sidebarName = "Tools";
+    path.column = SECTION_COLUMN_1;
+    AddSidebarEntry("Settings", "Tools", 1);
+
+    AddWidget(path, "Debug Windows", WIDGET_SEPARATOR_TEXT);
+    AddWidget(path, "Stats", WIDGET_WINDOW_BUTTON)
+        .CVar(CVAR_STATS_WINDOW_OPEN)
+        .RaceDisable(false)
+        .WindowName("Stats")
+        .HideInSearch(true)
+        .Options(WindowButtonOptions().Tooltip("Toggles the Stats window."));
+    AddWidget(path, "Console", WIDGET_WINDOW_BUTTON)
+        .CVar(CVAR_CONSOLE_WINDOW_OPEN)
+        .RaceDisable(false)
+        .WindowName("Console")
+        .HideInSearch(true)
+        .Options(WindowButtonOptions().Tooltip("Toggles the Console window."));
+    AddWidget(path, "Gfx Debugger", WIDGET_WINDOW_BUTTON)
+        .CVar(CVAR_GFX_DEBUGGER_WINDOW_OPEN)
+        .RaceDisable(false)
+        .WindowName("GfxDebuggerWindow")
+        .HideInSearch(true)
+        .Options(WindowButtonOptions().Tooltip("Toggles the graphics debugger window."));
 }
 
+/*
 void PortMenu::AddMenuWindows() {
     AddMenuEntry("Windows", CVAR_SETTING("Menu.WindowsSidebarSection"));
 
@@ -1104,6 +1143,7 @@ void PortMenu::AddMenuWindows() {
         .HideInSearch(true)
         .Options(WindowButtonOptions().Tooltip("Toggles the controller configuration window."));
 }
+*/
 
 void PortMenu::AddMenuAssets() {
     AddMenuEntry("Assets", CVAR_SETTING("Menu.AssetsSidebarSection"));
@@ -1305,7 +1345,7 @@ void PortMenu::AddMenuAbout() {
 
 void PortMenu::AddMenuElements() {
     AddMenuSettings();
-    AddMenuWindows();
+    //AddMenuWindows();
     AddMenuAssets();
     AddMenuAbout();
 

--- a/port/gui/PortMenu.cpp
+++ b/port/gui/PortMenu.cpp
@@ -1107,44 +1107,6 @@ void PortMenu::AddMenuSettings() {
         .Options(WindowButtonOptions().Tooltip("Toggles the graphics debugger window."));
 }
 
-/*
-void PortMenu::AddMenuWindows() {
-    AddMenuEntry("Windows", CVAR_SETTING("Menu.WindowsSidebarSection"));
-
-    WidgetPath path = { "Windows", "Tools", SECTION_COLUMN_1 };
-    AddSidebarEntry("Windows", "Tools", 1);
-    AddWidget(path, "Debug Windows", WIDGET_SEPARATOR_TEXT);
-    AddWidget(path, "Stats", WIDGET_WINDOW_BUTTON)
-        .CVar(CVAR_STATS_WINDOW_OPEN)
-        .RaceDisable(false)
-        .WindowName("Stats")
-        .HideInSearch(true)
-        .Options(WindowButtonOptions().Tooltip("Toggles the Stats window."));
-    AddWidget(path, "Console", WIDGET_WINDOW_BUTTON)
-        .CVar(CVAR_CONSOLE_WINDOW_OPEN)
-        .RaceDisable(false)
-        .WindowName("Console")
-        .HideInSearch(true)
-        .Options(WindowButtonOptions().Tooltip("Toggles the Console window."));
-    AddWidget(path, "Gfx Debugger", WIDGET_WINDOW_BUTTON)
-        .CVar(CVAR_GFX_DEBUGGER_WINDOW_OPEN)
-        .RaceDisable(false)
-        .WindowName("GfxDebuggerWindow")
-        .HideInSearch(true)
-        .Options(WindowButtonOptions().Tooltip("Toggles the graphics debugger window."));
-
-    path.sidebarName = "Input";
-    AddSidebarEntry("Windows", "Input", 1);
-    AddWidget(path, "Controller", WIDGET_SEPARATOR_TEXT);
-    AddWidget(path, "Controller Configuration", WIDGET_WINDOW_BUTTON)
-        .CVar(CVAR_CONTROLLER_CONFIGURATION_WINDOW_OPEN)
-        .RaceDisable(false)
-        .WindowName("Input Editor")
-        .HideInSearch(true)
-        .Options(WindowButtonOptions().Tooltip("Toggles the controller configuration window."));
-}
-*/
-
 void PortMenu::AddMenuAssets() {
     AddMenuEntry("Assets", CVAR_SETTING("Menu.AssetsSidebarSection"));
 
@@ -1345,7 +1307,6 @@ void PortMenu::AddMenuAbout() {
 
 void PortMenu::AddMenuElements() {
     AddMenuSettings();
-    //AddMenuWindows();
     AddMenuAssets();
     AddMenuAbout();
 

--- a/port/gui/PortMenu.h
+++ b/port/gui/PortMenu.h
@@ -31,7 +31,6 @@ class PortMenu : public Ship::Menu {
     WidgetInfo& AddWidget(WidgetPath& pathInfo, std::string widgetName, WidgetType widgetType);
     void AddMenuElements();
     void AddMenuSettings();
-    void AddMenuWindows();
     void AddMenuAssets();
     void AddMenuAbout();
 


### PR DESCRIPTION
Rebased version of #170 by @the-outcaster — folds the **Windows** top-level tab into **Settings** by adding `Input` and `Tools` sidebars there, and drops the now-empty `AddMenuWindows()` function.

Rebased onto current `main` because the original PR was opened against a ~7-month-older `PortMenu.cpp` and was outpaced by the menu growth since. Resolution sequencing:
- The new `Input` sidebar (just the Controller Configuration window button) lands right between `Gameplay` and `Controls`, since both `Input` and `Controls` are input-related.
- `Tools` (debug windows) lands at the end of `Settings`, after `Cheats`.
- Also removed the orphan `AddMenuWindows()` declaration in `PortMenu.h` (the original PR removed the body and the call but missed the header).

Build-verified on Windows (MSVC).

Closes #170

Co-authored-by: the-outcaster <linuxgamingcentral@pm.me>