### PR TITLE
Discord Rich Presence (rebased from #173)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -3,6 +3,7 @@ cmake_minimum_required(VERSION 3.24.0 FATAL_ERROR)
 project(ssb64 LANGUAGES C CXX)
 
 include(ExternalProject)
+include(FetchContent) # pull discord-rpc from GitHub
 
 # Version string for the built-in updater. String-compared exactly against
 # the name returned by GitHub's /tags API, so it must match the release tag
@@ -462,6 +463,23 @@ if (NOT MSVC)
 endif()
 
 ################################################################################
+# Fetch Discord RPC
+################################################################################
+set(BUILD_EXAMPLES OFF CACHE BOOL "" FORCE)
+FetchContent_Declare(
+    discord_rpc
+    GIT_REPOSITORY https://github.com/discordapp/discord-rpc.git
+    GIT_TAG        v3.4.0
+    PATCH_COMMAND  ${CMAKE_COMMAND} -E rm -f .clang-format
+)
+FetchContent_MakeAvailable(discord_rpc)
+
+# Suppress GCC 14 strict template errors in discord-rpc's bundled RapidJSON
+if(CMAKE_CXX_COMPILER_ID STREQUAL "GNU" AND CMAKE_CXX_COMPILER_VERSION VERSION_GREATER_EQUAL "14.0")
+    target_compile_options(discord-rpc PRIVATE -Wno-template-body)
+endif()
+
+################################################################################
 # Executable target — port C++ code + decomp object library
 ################################################################################
 
@@ -500,15 +518,16 @@ target_include_directories(${PROJECT_NAME} PRIVATE
     ${CMAKE_CURRENT_SOURCE_DIR}/port
     ${CMAKE_CURRENT_SOURCE_DIR}/debug_tools
     ${SSB64_ICON_GEN_DIR}                         # Generated icon header (port_icon_data.h)
+    ${discord_rpc_SOURCE_DIR}/include             # Discord Rich Presence
 )
 
 ################################################################################
 # Link libultraship and Torch
 ################################################################################
 
-add_dependencies(${PROJECT_NAME} libultraship TorchExternal)
+add_dependencies(${PROJECT_NAME} libultraship TorchExternal discord-rpc)
 add_dependencies(ssb64_game GenerateCreditsAssets)
-target_link_libraries(${PROJECT_NAME} PRIVATE libultraship)
+target_link_libraries(${PROJECT_NAME} PRIVATE libultraship discord-rpc)
 
 ################################################################################
 # Platform-specific settings

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -465,7 +465,17 @@ endif()
 ################################################################################
 # Fetch Discord RPC
 ################################################################################
+# discord-rpc v3.4.0's CMakeLists declares cmake_minimum_required(VERSION 2.x),
+# which CMake 3.30+ refuses to honor. Force a baseline policy version for the
+# fetched subdir so the build still configures with current CMake.
+set(CMAKE_POLICY_VERSION_MINIMUM 3.5 CACHE INTERNAL "" FORCE)
 set(BUILD_EXAMPLES OFF CACHE BOOL "" FORCE)
+# BattleShip links against the static CRT on Windows (see the
+# MSVC_RUNTIME_LIBRARY setting on the ssb64 / ssb64_game targets below).
+# discord-rpc's own CMakeLists guards the static-CRT switch behind
+# USE_STATIC_CRT — opt in so the produced discord-rpc.lib uses the same
+# /MT[d] runtime, otherwise the final link fails with LNK2038.
+set(USE_STATIC_CRT ON CACHE BOOL "" FORCE)
 FetchContent_Declare(
     discord_rpc
     GIT_REPOSITORY https://github.com/discordapp/discord-rpc.git
@@ -473,6 +483,13 @@ FetchContent_Declare(
     PATCH_COMMAND  ${CMAKE_COMMAND} -E rm -f .clang-format
 )
 FetchContent_MakeAvailable(discord_rpc)
+# Belt and suspenders: enforce the runtime-library property on the
+# produced target directly so it survives a future cmake_policy(CMP0091)
+# propagation behavior change.
+if(MSVC AND TARGET discord-rpc)
+    set_property(TARGET discord-rpc PROPERTY
+        MSVC_RUNTIME_LIBRARY "MultiThreaded$<$<CONFIG:Debug>:Debug>")
+endif()
 
 # Suppress GCC 14 strict template errors in discord-rpc's bundled RapidJSON
 if(CMAKE_CXX_COMPILER_ID STREQUAL "GNU" AND CMAKE_CXX_COMPILER_VERSION VERSION_GREATER_EQUAL "14.0")

--- a/port/enhancements/DiscordRichPresence.cpp
+++ b/port/enhancements/DiscordRichPresence.cpp
@@ -1,0 +1,219 @@
+#include "enhancements.h"
+#include <stdint.h>
+#include <time.h>
+#include <string.h>
+
+// Include your port's logging system
+#include "port_log.h"
+
+// LibUltraShip includes for CVar access
+#include <libultraship/libultraship.h>
+#include <libultraship/bridge.h>
+
+// Discord SDK header
+#include <discord_rpc.h>
+
+#define DISCORD_CLIENT_ID "1503877021615390741"
+
+extern "C" {
+    // Fetches the current scene ID from the game engine
+    unsigned char port_diag_get_scene_curr(void);
+}
+
+static bool g_drpInitialized = false;
+static int64_t g_startTime = 0;
+
+// ---------------------------------------------------------
+// DISCORD SDK CALLBACKS
+// ---------------------------------------------------------
+
+static void handleDiscordReady(const DiscordUser* connectedUser) {
+    port_log("SSB64 DRP: Successfully connected to Discord as %s\n", connectedUser->username);
+}
+
+static void handleDiscordDisconnected(int errcode, const char* message) {
+    port_log("SSB64 DRP: Disconnected from Discord (Code %d: %s)\n", errcode, message);
+}
+
+static void handleDiscordError(int errcode, const char* message) {
+    port_log("SSB64 DRP: Discord SDK Error (Code %d: %s)\n", errcode, message);
+}
+
+// ---------------------------------------------------------
+// INTERNAL LIFECYCLE
+// ---------------------------------------------------------
+
+static void DRP_Init() {
+    if (g_drpInitialized) return;
+
+    port_log("SSB64 DRP: Initializing Discord SDK...\n");
+
+    DiscordEventHandlers handlers;
+    memset(&handlers, 0, sizeof(handlers));
+
+    // Attach our logging callbacks
+    handlers.ready = handleDiscordReady;
+    handlers.disconnected = handleDiscordDisconnected;
+    handlers.errored = handleDiscordError;
+
+    Discord_Initialize(DISCORD_CLIENT_ID, &handlers, 1, NULL);
+
+    g_startTime = time(NULL);
+    g_drpInitialized = true;
+}
+
+static void DRP_Shutdown() {
+    if (!g_drpInitialized) return;
+
+    port_log("SSB64 DRP: Shutting down Discord SDK...\n");
+
+    Discord_ClearPresence();
+    Discord_Shutdown();
+
+    g_drpInitialized = false;
+}
+
+// ---------------------------------------------------------
+// PUBLIC FUNCTIONS
+// ---------------------------------------------------------
+
+namespace ssb64 {
+    namespace enhancements {
+
+        void UpdateDiscordPresence(const char* gameState, const char* matchDetails) {
+            bool isDRPEnabled = CVarGetInteger("gSettings.Menu.EnableDRP", 0) != 0;
+
+            if (!isDRPEnabled) {
+                if (g_drpInitialized) {
+                    port_log("SSB64 DRP: CVar turned off, triggering shutdown.\n");
+                    DRP_Shutdown();
+                }
+                return;
+            }
+
+            if (!g_drpInitialized) {
+                DRP_Init();
+            }
+
+            port_log("SSB64 DRP: Updating presence -> State: '%s' | Details: '%s'\n", gameState, matchDetails);
+
+            DiscordRichPresence discordPresence;
+            memset(&discordPresence, 0, sizeof(discordPresence));
+
+            discordPresence.state = gameState;
+            discordPresence.details = matchDetails;
+            discordPresence.startTimestamp = g_startTime;
+            discordPresence.largeImageKey = "battleship_logo";
+            discordPresence.largeImageText = "Unofficial Smash 64 PC Port";
+
+            Discord_UpdatePresence(&discordPresence);
+        }
+
+        static void UpdatePresenceForScene(unsigned char sceneId) {
+            switch (sceneId) {
+                // --- MENUS ---
+                case 1:  // Title
+                    UpdateDiscordPresence("Title Screen", "Press Start");
+                    break;
+                case 7:  // Main Menu
+                case 8:  // 1P Mode Menu
+                case 9:  // VS Mode Menu
+                case 10: // VS Options
+                case 11: // VS Item Switch
+                case 15: // Screen Adjust
+                    UpdateDiscordPresence("In Menus", "Choosing a Game Mode");
+                    break;
+                case 25: // Records Screen
+                case 26: // Character Data Screen
+                    UpdateDiscordPresence("In Menus", "Looking at Stats");
+                    break;
+
+                // --- CHARACTER SELECT (CSS) ---
+                case 16: // VS Character Select
+                    // --- 1P / TRAINING CHARACTER SELECT ---
+                case 17: // 1P Game Players
+                    UpdateDiscordPresence("CSS", "Choosing a Fighter");
+                    break;
+                case 18: // Training Mode Players
+                    UpdateDiscordPresence("Training Mode", "Choosing a Fighter");
+                    break;
+                case 19: // Bonus 1 Players
+                    UpdateDiscordPresence("Break the Targets", "Choosing a Fighter");
+                    break;
+                case 20: // Bonus 2 Players
+                    UpdateDiscordPresence("Board the Platforms", "Choosing a Fighter");
+                    break;
+
+                // --- STAGE SELECT ---
+                case 21: // Stage Select
+                    UpdateDiscordPresence("Stage Select", "Picking a Stage");
+                    break;
+
+                // --- IN-GAME & RESULTS ---
+                case 14: // 1P VS Screen (The "VS" splash before a fight)
+
+                // --- GAMEPLAY ---
+                case 22: // VS Battle In-Game
+                    UpdateDiscordPresence("Versus Mode", "Brawling");
+                    break;
+                case 23: // 1P Gameplay (Classic, Training, Bonus)
+                    UpdateDiscordPresence("Single Player", "In a Match");
+                    break;
+                case 24: // VS Results Screen
+                    UpdateDiscordPresence("Post-Match", "Viewing Results");
+                    break;
+                case 13: // Challenger Approaching Screen
+                    UpdateDiscordPresence("Challenger Approaching!", "A New Foe Has Appeared");
+                    break;
+
+                // --- INTRO & CUTSCENES ---
+                case 27: // N64 Logo / Startup
+                case 28: // Opening Room (Master Hand desk)
+                case 29: case 30: case 31: case 32: case 33: case 34:
+                case 35: case 36: case 37: case 38: case 39: case 40:
+                case 41: case 42: case 43: case 44: case 45: case 46:
+                    UpdateDiscordPresence("Watching the Intro", "Nostalgia Trip");
+                    break;
+
+                // --- FALLBACK (Including Debug Menus & Messages) ---
+                case 0:  // No Controller Screen
+                case 12: // Unlock Message
+                default:
+                    UpdateDiscordPresence("in the game", "Somewhere");
+                    break;
+            }
+        }
+
+        void TickDiscordPresence() {
+            // 1. Read the menu toggle
+            bool isDRPEnabled = CVarGetInteger("gSettings.Menu.EnableDRP", 0) != 0;
+
+            // Remember the last scene so we don't spam Discord's API every frame
+            static unsigned char s_lastScene = 255;
+
+            if (isDRPEnabled) {
+                // Fetch the current scene from the game engine
+                unsigned char currentScene = port_diag_get_scene_curr();
+
+                // If the scene changed (or the game just booted), push an update!
+                if (currentScene != s_lastScene) {
+                    s_lastScene = currentScene;
+                    UpdatePresenceForScene(currentScene);
+                }
+
+                // Process SDK callbacks if it's currently running
+                if (g_drpInitialized) {
+                    Discord_RunCallbacks();
+                }
+            }
+            else if (g_drpInitialized) {
+                // If the player unchecks the box mid-game, shut it down immediately
+                DRP_Shutdown();
+
+                // Reset our tracker so it updates instantly if they check the box again
+                s_lastScene = 255;
+            }
+        }
+
+    } // namespace enhancements
+} // namespace ssb64

--- a/port/enhancements/enhancements.h
+++ b/port/enhancements/enhancements.h
@@ -63,6 +63,10 @@ const char* AnalogRemapDeadzoneCVarName(int playerIndex);
 const char* AnalogRemapRangeCVarName(int playerIndex);
 const char* WidescreenCVarName();
 
+// Discord Rich Presence
+void UpdateDiscordPresence(const char* gameState, const char* matchDetails);
+void TickDiscordPresence();
+
 // Updater functions
 void CheckForUpdatesAsync(bool force = false);
 void StartGameUpdate();

--- a/port/gameloop.cpp
+++ b/port/gameloop.cpp
@@ -550,6 +550,8 @@ void PortPushFrame(void)
 	port_enhancement_stage_hazards_tick();
 	port_widescreen_tick();
 
+	ssb64::enhancements::TickDiscordPresence(); // DRP
+
 	sFrameCount++;
 
 	/* VI-style idle presentation: when no gfx task was submitted this VI,

--- a/port/gui/PortMenu.cpp
+++ b/port/gui/PortMenu.cpp
@@ -831,6 +831,12 @@ void PortMenu::AddMenuSettings() {
         .RaceDisable(false)
         .Options(CheckboxOptions().Tooltip("Gives the search input focus when it becomes visible."));
 
+    // DRP
+    AddWidget(path, "Enable Discord Rich Presence", WIDGET_CVAR_CHECKBOX)
+        .CVar(CVAR_SETTING("Menu.EnableDRP"))
+        .RaceDisable(false)
+        .Options(CheckboxOptions().Tooltip("Adds Discord Rich Presence (DRP)."));
+
     AddWidget(path, "Open App Files Folder", WIDGET_BUTTON)
         .RaceDisable(false)
         .Callback([](WidgetInfo&) {


### PR DESCRIPTION
Rebased version of #173 by @the-outcaster — adds a **Discord Rich Presence** checkbox under **Settings → General**, fetching `discord-rpc` v3.4.0 via CMake `FetchContent` and ticking the SDK from the per-frame loop. Scene ID drives the presence string (Menus / CSS / Stage Select / In-Match / etc.).

### Changes from the original PR

The original PR didn't build on Windows. Added one fix commit on top:

- **`set(CMAKE_POLICY_VERSION_MINIMUM 3.5)`** — `discord-rpc` v3.4.0 declares `cmake_minimum_required(VERSION 2.x)`, which CMake 3.30+ refuses to honor outright. Without this the configure step fails.
- **`set(USE_STATIC_CRT ON)`** + `set_property(... MSVC_RUNTIME_LIBRARY ...)` — BattleShip links the static MSVC CRT (`/MT[d]`), but `discord-rpc` defaults to `/MD[d]`. Mixing them trips `LNK2038` ("RuntimeLibrary mismatch"). Opt into the subproject's static-CRT switch and pin the runtime-library property on the produced target as a hedge against CMP0091 propagation behavior changes.

Build-verified on Windows (MSVC) after these fixes.

Closes #173

Co-authored-by: the-outcaster <linuxgamingcentral@pm.me>