### PR TITLE
Competitive Ruleset + QoL toggles (rebased from #196)

### DIFF
--- a/port/enhancements/BootToVSCSS.cpp
+++ b/port/enhancements/BootToVSCSS.cpp
@@ -1,0 +1,16 @@
+#include "enhancements.h"
+#include <libultraship/bridge/consolevariablebridge.h>
+
+namespace ssb64 {
+    namespace enhancements {
+
+        const char* BootToVSCSSCVarName() {
+            return "gEnhancements.BootToVSCSS";
+        }
+
+    } // namespace enhancements
+} // namespace ssb64
+
+extern "C" int port_enhancement_boot_to_vs_css(void) {
+    return CVarGetInteger(ssb64::enhancements::BootToVSCSSCVarName(), 0) != 0;
+}

--- a/port/enhancements/CompRuleset.cpp
+++ b/port/enhancements/CompRuleset.cpp
@@ -1,0 +1,18 @@
+#include "enhancements.h"
+#include <libultraship/bridge/consolevariablebridge.h>
+
+namespace ssb64 {
+    namespace enhancements {
+
+        const char* CompRulesetCVarName() {
+            return "gEnhancements.CompRuleset";
+        }
+
+    } // namespace enhancements
+} // namespace ssb64
+
+extern "C" int port_get_comp_ruleset(void) {
+    // Reads the CVar from the UI bridge.
+    // The != 0 ensures it strictly returns a 1 or 0 boolean state for the C engine.
+    return CVarGetInteger(ssb64::enhancements::CompRulesetCVarName(), 0) != 0;
+}

--- a/port/enhancements/CpuLevel9.cpp
+++ b/port/enhancements/CpuLevel9.cpp
@@ -1,0 +1,16 @@
+#include "enhancements.h"
+#include <libultraship/bridge/consolevariablebridge.h>
+
+namespace ssb64 {
+    namespace enhancements {
+
+        const char* CpuLevel9CVarName() {
+            return "gEnhancements.CpuLevel9";
+        }
+
+    } // namespace enhancements
+} // namespace ssb64
+
+extern "C" int port_enhancement_cpu_level_9(void) {
+    return CVarGetInteger(ssb64::enhancements::CpuLevel9CVarName(), 0) != 0;
+}

--- a/port/enhancements/NeutralSpawns.cpp
+++ b/port/enhancements/NeutralSpawns.cpp
@@ -1,0 +1,16 @@
+#include "enhancements.h"
+#include <libultraship/bridge/consolevariablebridge.h>
+
+namespace ssb64 {
+    namespace enhancements {
+
+        const char* NeutralSpawnsCVarName() {
+            return "gEnhancements.NeutralSpawns";
+        }
+
+    } // namespace enhancements
+} // namespace ssb64
+
+extern "C" int port_enhancement_neutral_spawns(void) {
+    return CVarGetInteger(ssb64::enhancements::NeutralSpawnsCVarName(), 0) != 0;
+}

--- a/port/enhancements/SkipResultsScreen.cpp
+++ b/port/enhancements/SkipResultsScreen.cpp
@@ -1,0 +1,16 @@
+#include "enhancements.h"
+#include <libultraship/bridge/consolevariablebridge.h>
+
+namespace ssb64 {
+    namespace enhancements {
+
+        const char* SkipResultsScreenCVarName() {
+            return "gEnhancements.SkipResultsScreen";
+        }
+
+    } // namespace enhancements
+} // namespace ssb64
+
+extern "C" int port_enhancement_skip_results_screen(void) {
+    return CVarGetInteger(ssb64::enhancements::SkipResultsScreenCVarName(), 0) != 0;
+}

--- a/port/enhancements/enhancements.h
+++ b/port/enhancements/enhancements.h
@@ -48,6 +48,24 @@ void port_enhancement_analog_remap(int player_index, signed char* stick_x, signe
 
 int port_cheat_unlock_all_active(void);
 
+// competitive ruleset enhancements
+int port_get_comp_ruleset(void);
+void port_apply_comp_ruleset_overrides(void);
+void port_cleanup_comp_ruleset(void);
+void port_comp_ruleset_skip_stageselect(void);
+
+// neutral spawn points on dreamland
+int port_enhancement_neutral_spawns(void);
+
+// boot to CSS
+int port_enhancement_boot_to_vs_css(void);
+
+// skip results screen
+int port_enhancement_skip_results_screen(void);
+
+// cpu behavior
+int port_enhancement_cpu_level_9(void);
+
 #ifdef __cplusplus
 }
 
@@ -62,6 +80,11 @@ const char* AnalogRemapCVarName(int playerIndex);
 const char* AnalogRemapDeadzoneCVarName(int playerIndex);
 const char* AnalogRemapRangeCVarName(int playerIndex);
 const char* WidescreenCVarName();
+const char* CompRulesetCVarName();
+const char* NeutralSpawnsCVarName();
+const char* BootToVSCSSCVarName();
+const char* SkipResultsScreenCVarName();
+const char* CpuLevel9CVarName();
 
 // Discord Rich Presence
 void UpdateDiscordPresence(const char* gameState, const char* matchDetails);

--- a/port/gui/PortMenu.cpp
+++ b/port/gui/PortMenu.cpp
@@ -987,6 +987,37 @@ void PortMenu::AddMenuSettings() {
                      .ComboMap(kHitboxViewMap)
                      .DefaultIndex(0));
 
+    // --- Competitive ruleset (still in Gameplay sidebar) ---
+    AddWidget(path, "Rules", WIDGET_SEPARATOR_TEXT);
+    AddWidget(path, "Use Competitive Ruleset", WIDGET_CVAR_CHECKBOX)
+        .CVar(ssb64::enhancements::CompRulesetCVarName())
+        .RaceDisable(false)
+        .Options(CheckboxOptions().Tooltip("Forces the following in VS Mode: \n"
+                                           "- 4 Stocks \n"
+                                           "- 8 Minutes \n"
+                                           "- Items Off \n"
+                                           "- Team Attack ON \n"
+                                           "- Dream Land only"));
+    AddWidget(path, "Neutral Spawns on Dreamland", WIDGET_CVAR_CHECKBOX)
+        .CVar(ssb64::enhancements::NeutralSpawnsCVarName())
+        .RaceDisable(false)
+        .Options(CheckboxOptions().Tooltip("Forces balanced, opposite-side starting positions for 1v1 and Team Battles."));
+
+    // --- Quality-of-Life (still in Gameplay sidebar) ---
+    AddWidget(path, "Quality-of-Life", WIDGET_SEPARATOR_TEXT);
+    AddWidget(path, "Boot to VS CSS", WIDGET_CVAR_CHECKBOX)
+        .CVar(ssb64::enhancements::BootToVSCSSCVarName())
+        .RaceDisable(false)
+        .Options(CheckboxOptions().Tooltip("Skips the intro sequences and boots directly to the VS Mode Character Select Screen."));
+    AddWidget(path, "Skip Results Screen", WIDGET_CVAR_CHECKBOX)
+        .CVar(ssb64::enhancements::SkipResultsScreenCVarName())
+        .RaceDisable(false)
+        .Options(CheckboxOptions().Tooltip("Skips the victory podium and returns directly to the Character Select Screen."));
+    AddWidget(path, "Force CPU Level 9", WIDGET_CVAR_CHECKBOX)
+        .CVar(ssb64::enhancements::CpuLevel9CVarName())
+        .RaceDisable(false)
+        .Options(CheckboxOptions().Tooltip("Automatically forces all CPU players to Level 9."));
+
     // --- Input customization ---
     path.sidebarName = "Input";
     path.column = SECTION_COLUMN_1;


### PR DESCRIPTION
Rebased version of #196 by @the-outcaster — adds a **Competitive Ruleset** toggle and several QoL settings under **Settings → Gameplay**:

- **Use Competitive Ruleset** — forces 4 stocks / 8-minute timer / items off / team attack on / Dream Land only in VS mode.
- **Neutral Spawns on Dreamland** — balanced 1v1 + 2v2 starting positions.
- **Boot to VS CSS** — skip intro, land on the VS Mode CSS at startup.
- **Skip Results Screen** — go straight back to CSS after a match.
- **Force CPU Level 9** — auto-set all CPUs to level 9.

### Decomp side

Pairs with decomp PR JRickey/ssb-decomp-re#5 (the C-side hooks). Decomp pointer bumped to **`d208de7b9`** — that commit is the rebased version of PR #5 sitting on top of current `port-patches`, pushed to the `agent/comp-ruleset` branch on `JRickey/ssb-decomp-re`. After this PR merges, `port-patches` should be fast-forwarded to that SHA and decomp PR #5 closed.

### Conflict resolution

- The original PR added its widgets just after the Hitbox View widget; #170 (already merged) inserts its new `Input` sidebar at the same spot. Resolved by placing **Competitive Ruleset + QoL widgets first** (they stay in the `Gameplay` sidebar with the existing `path`), **then** the `Input` sidebar transition. Functionally identical to merging them independently.

Build-verified on Windows (MSVC).

Closes #196

Co-authored-by: the-outcaster <linuxgamingcentral@pm.me>