### PR TITLE
Rename input and controls tabs + widen the left column in ESC menu

### DIFF
--- a/port/gui/Menu.cpp
+++ b/port/gui/Menu.cpp
@@ -915,7 +915,7 @@ void Menu::DrawElement() {
     ImGui::SetNextWindowPos(pos + style.ItemSpacing * 2);
 
     // Increase sidebar width on larger screens to accomodate people scaling their menus.
-    float sidebarWidth = 200 - style.ItemSpacing.x;
+    float sidebarWidth = 300 - style.ItemSpacing.x;
     if (menuSize.x > 1600) {
         sidebarWidth = menuSize.x * 0.15f;
     }

--- a/port/gui/PortMenu.cpp
+++ b/port/gui/PortMenu.cpp
@@ -1037,9 +1037,9 @@ void PortMenu::AddMenuSettings() {
         .Options(CheckboxOptions().Tooltip("Automatically forces all CPU players to Level 9."));
 
     // --- Input customization ---
-    path.sidebarName = "Input";
+    path.sidebarName = "Input Mappings";
     path.column = SECTION_COLUMN_1;
-    AddSidebarEntry("Settings", "Input", 1);
+    AddSidebarEntry("Settings", "Input Mappings", 1);
 
     AddWidget(path, "Controller", WIDGET_SEPARATOR_TEXT);
     AddWidget(path, "Controller Configuration", WIDGET_WINDOW_BUTTON)
@@ -1050,9 +1050,9 @@ void PortMenu::AddMenuSettings() {
         .Options(WindowButtonOptions().Tooltip("Toggles the controller configuration window."));
 
     // --- Controls sidebar: per-player input remapping ---
-    path.sidebarName = "Controls";
+    path.sidebarName = "Control Enhancements";
     path.column = SECTION_COLUMN_1;
-    AddSidebarEntry("Settings", "Controls", 1);
+    AddSidebarEntry("Settings", "Control Enhancements", 1);
 
     for (int p = 0; p < PORT_ENHANCEMENT_MAX_PLAYERS; ++p) {
         const std::string playerLabel = fmt::format("Player {}", p + 1);


### PR DESCRIPTION
<img width="1605" height="1213" alt="Screenshot_20260525_143940" src="https://github.com/user-attachments/assets/0dd36a91-729e-400a-875e-52c59f4b0ec5" />

Renames the "Input" and "Controls" tabs to "Input Mappings" and "Control Enhancements" respectively to avoid confusion. Also slightly widens the left column so that the text doesn't clip.