### PR TITLE
Add checkbox options for Z-cancellation options

### DIFF
--- a/port/enhancements/AutoZCancel.cpp
+++ b/port/enhancements/AutoZCancel.cpp
@@ -1,0 +1,16 @@
+#include "enhancements.h"
+#include <libultraship/bridge/consolevariablebridge.h>
+
+namespace ssb64 {
+    namespace enhancements {
+
+        const char* AutoZCancelCVarName() {
+            return "gEnhancements.CasualRules.AutoZCancel";
+        }
+
+    } // namespace enhancements
+} // namespace ssb64
+
+extern "C" int port_enhancement_IsAutoZCancelEnabled(void) {
+    return CVarGetInteger(ssb64::enhancements::AutoZCancelCVarName(), 0) != 0;
+}

--- a/port/enhancements/FailedZCancelFlash.cpp
+++ b/port/enhancements/FailedZCancelFlash.cpp
@@ -1,0 +1,16 @@
+#include "enhancements.h"
+#include <libultraship/bridge/consolevariablebridge.h>
+
+namespace ssb64 {
+    namespace enhancements {
+
+        const char* FailedZCancelCVarName() {
+            return "gEnhancements.CasualRules.FailedZCancelFlash";
+        }
+
+    } // namespace enhancements
+} // namespace ssb64
+
+extern "C" int port_enhancement_IsFailedZCancelFlashEnabled(void) {
+    return CVarGetInteger(ssb64::enhancements::FailedZCancelCVarName(), 0) != 0;
+}

--- a/port/enhancements/enhancements.h
+++ b/port/enhancements/enhancements.h
@@ -57,6 +57,10 @@ void port_comp_ruleset_skip_stageselect(void);
 // neutral spawn points on dreamland
 int port_enhancement_neutral_spawns(void);
 
+// z-cancel options
+int port_enhancement_IsAutoZCancelEnabled(void);
+int port_enhancement_IsFailedZCancelFlashEnabled(void);
+
 // boot to CSS
 int port_enhancement_boot_to_vs_css(void);
 
@@ -82,6 +86,8 @@ const char* AnalogRemapRangeCVarName(int playerIndex);
 const char* WidescreenCVarName();
 const char* CompRulesetCVarName();
 const char* NeutralSpawnsCVarName();
+const char* AutoZCancelCVarName();
+const char* FailedZCancelCVarName();
 const char* BootToVSCSSCVarName();
 const char* SkipResultsScreenCVarName();
 const char* CpuLevel9CVarName();

--- a/port/gui/PortMenu.cpp
+++ b/port/gui/PortMenu.cpp
@@ -1006,7 +1006,7 @@ void PortMenu::AddMenuSettings() {
                      .DefaultIndex(0));
 
     // --- Competitive ruleset (still in Gameplay sidebar) ---
-    AddWidget(path, "Rules", WIDGET_SEPARATOR_TEXT);
+    AddWidget(path, "Competitive Rules", WIDGET_SEPARATOR_TEXT);
     AddWidget(path, "Use Competitive Ruleset", WIDGET_CVAR_CHECKBOX)
         .CVar(ssb64::enhancements::CompRulesetCVarName())
         .RaceDisable(false)
@@ -1020,6 +1020,17 @@ void PortMenu::AddMenuSettings() {
         .CVar(ssb64::enhancements::NeutralSpawnsCVarName())
         .RaceDisable(false)
         .Options(CheckboxOptions().Tooltip("Forces balanced, opposite-side starting positions for 1v1 and Team Battles."));
+
+    // --- Z-Cancel options ---
+    AddWidget(path, "Z-Cancel Options", WIDGET_SEPARATOR_TEXT);
+    AddWidget(path, "Auto Z-Cancel", WIDGET_CVAR_CHECKBOX)
+        .CVar(ssb64::enhancements::AutoZCancelCVarName())
+        .RaceDisable(false)
+        .Options(CheckboxOptions().Tooltip("Automatically cancels the landing lag from aerial attacks."));
+    AddWidget(path, "Flash on Failed Z-Cancel", WIDGET_CVAR_CHECKBOX)
+        .CVar(ssb64::enhancements::FailedZCancelCVarName())
+        .RaceDisable(false)
+        .Options(CheckboxOptions().Tooltip("Makes your character temporarily flash in flames on a failed Z-Cancel."));
 
     // --- Quality-of-Life (still in Gameplay sidebar) ---
     AddWidget(path, "Quality-of-Life", WIDGET_SEPARATOR_TEXT);


### PR DESCRIPTION
https://github.com/user-attachments/assets/898afa9b-484b-4fb7-b434-280133f87740

As requested per https://github.com/JRickey/BattleShip/issues/213, this adds the following options to Settings -> Gameplay:
- a toggle to auto Z-cancel all aerial attacks
- a toggle to flash the character in flames temporarily (no damage is caused) if auto-cancel is disabled but the player fails to land a Z-Cancel

The associated PR for the decomp is here: https://github.com/JRickey/ssb-decomp-re/pull/6