### PR TITLE
Fix missing clouds on Yoshi's Story

### DIFF
--- a/port/enhancements/DisableStageHazards.cpp
+++ b/port/enhancements/DisableStageHazards.cpp
@@ -10,6 +10,7 @@ constexpr const char* kStageHazardsDisabledCVar = "gEnhancements.StageHazardsDis
 constexpr unsigned char kSceneVSBattle = 22;
 constexpr unsigned char kScene1PGame = 52;
 constexpr unsigned char kScene1PTrainingMode = 54;
+constexpr unsigned char kStageYoshi = 5; // Verify this ID! Yoshi's Island/Story is typically 5.
 
 constexpr unsigned char kBattleStageEnd = 8;
 constexpr unsigned char kStageSector = 1;
@@ -143,6 +144,7 @@ extern "C" {
     extern SCBattleStatePrefix* gSCManagerBattleState;
     extern GObj* gGCCommonLinks[];
     void gcEjectGObj(GObj* gobj);
+    void grYosterStopCloudEvaporation(void);
 }
 
 namespace {
@@ -211,6 +213,11 @@ void LatchBattleSettingIfNeeded() {
 }
 
 void PauseGroundHazardProcesses() {
+    // Whitelist Yoshi's Story entirely since its priority >= 4 processes are just platforms, not hazards
+    if (IsCurrentStage(kStageYoshi)) {
+        return;
+    }
+
     for (GObj* gobj = gGCCommonLinks[kLinkGround]; gobj != nullptr; gobj = gobj->link_next) {
         for (GObjProcess* proc = gobj->gobjproc_head; proc != nullptr; proc = proc->link_next) {
             if (proc->priority >= 4) {
@@ -306,6 +313,11 @@ void ApplyHazardDisable() {
     PauseGroundHazardProcesses();
     EjectGroundHazardWeapons();
     EjectGroundHazardItems();
+
+    // freeze evaporation timer on Yoshi's
+    if (IsCurrentStage(kStageYoshi)) {
+        grYosterStopCloudEvaporation();
+    }
 }
 
 } // namespace

--- a/port/enhancements/DisableStageHazards.cpp
+++ b/port/enhancements/DisableStageHazards.cpp
@@ -10,7 +10,7 @@ constexpr const char* kStageHazardsDisabledCVar = "gEnhancements.StageHazardsDis
 constexpr unsigned char kSceneVSBattle = 22;
 constexpr unsigned char kScene1PGame = 52;
 constexpr unsigned char kScene1PTrainingMode = 54;
-constexpr unsigned char kStageYoshi = 5; // Verify this ID! Yoshi's Island/Story is typically 5.
+constexpr unsigned char kStageYoshi = 5;
 
 constexpr unsigned char kBattleStageEnd = 8;
 constexpr unsigned char kStageSector = 1;


### PR DESCRIPTION
Ensures the clouds on Yoshi's Story remain visible when the user disables stage hazards.

The associated decomp PR also ensures the clouds don't evaporate when a character is standing on it longer than two seconds: https://github.com/JRickey/ssb-decomp-re/pull/7