### PR TITLE
Add music shuffler and music selection screen

### DIFF
--- a/port/enhancements/MusicSelection.cpp
+++ b/port/enhancements/MusicSelection.cpp
@@ -1,0 +1,70 @@
+#include "enhancements.h"
+#include <libultraship/bridge/consolevariablebridge.h>
+
+#include <cstdint>
+#include <cstdlib>
+
+constexpr const char* kMusicSelectionCVar = "gEnhancements.MusicSelection";
+
+namespace {
+    // Tracks whether the player is currently picking a song
+    bool sIsSelectingMusic = false;
+
+    // The same pool of playable stage tracks used in ShuffleMusic.cpp
+    const uint32_t kShufflePool[] = {
+        0, 1, 2, 4, 5, 6, 7, 8, 9, 36, 37, 25
+    };
+    constexpr size_t kShufflePoolSize = sizeof(kShufflePool) / sizeof(kShufflePool[0]);
+}
+
+extern "C" {
+    // This variable lives in ShuffleMusic.cpp. We declare it here so we can update it.
+    extern int32_t gManualMusicSelection;
+
+    // Called when the stage select screen is loaded to reset the state
+    void port_enhancement_music_select_reset(void) {
+        sIsSelectingMusic = false;
+    }
+
+    // Returns:
+    // 0 = CVar is off (Do normal behavior)
+    // 1 = Phase 1 (Stage locked, wait for music selection)
+    // 2 = Phase 2 (Music locked, proceed to battle)
+    int32_t port_enhancement_music_select_handle_a(uint32_t bgm_id) {
+        if (CVarGetInteger(kMusicSelectionCVar, 0) == 0) {
+            return 0;
+        }
+
+        if (!sIsSelectingMusic) {
+            sIsSelectingMusic = true;
+            return 1;
+        } else {
+            // 0xFFFF is the flag sent by C if the player selects the "Random" stage slot
+            if (bgm_id == 0xFFFF) {
+                bgm_id = kShufflePool[std::rand() % kShufflePoolSize];
+            }
+            gManualMusicSelection = bgm_id;
+            sIsSelectingMusic = false;
+            return 2;
+        }
+    }
+
+    // Returns: 1 if the B button canceled the music selection, 0 if normal behavior
+    int32_t port_enhancement_music_select_handle_b(void) {
+        if (sIsSelectingMusic) {
+            sIsSelectingMusic = false;
+            return 1;
+        }
+        return 0;
+    }
+}
+
+namespace ssb64 {
+    namespace enhancements {
+
+        const char* MusicSelectionCVarName() {
+            return kMusicSelectionCVar;
+        }
+
+    } // namespace enhancements
+} // namespace ssb64

--- a/port/enhancements/ShuffleMusic.cpp
+++ b/port/enhancements/ShuffleMusic.cpp
@@ -1,0 +1,90 @@
+#include "enhancements.h"
+#include <libultraship/bridge/consolevariablebridge.h>
+
+#include <cstddef>
+#include <cstdint>
+#include <cstdlib>
+#include <ctime>
+
+constexpr const char* kShuffleMusicCVar = "gEnhancements.ShuffleMusic";
+
+// Stage BGM integer mappings derived from gmMusicID
+constexpr uint32_t nSYAudioBGMPupupu = 0;   // Dream Land
+constexpr uint32_t nSYAudioBGMZebes = 1;    // Planet Zebes
+constexpr uint32_t nSYAudioBGMInishie = 2;  // Mushroom Kingdom
+constexpr uint32_t nSYAudioBGMSector = 4;   // Sector Z
+constexpr uint32_t nSYAudioBGMJungle = 5;   // Kongo Jungle
+constexpr uint32_t nSYAudioBGMCastle = 6;   // Peach's Castle
+constexpr uint32_t nSYAudioBGMYamabuki = 7; // Saffron City
+constexpr uint32_t nSYAudioBGMYoster = 8;   // Yoshi's Island
+constexpr uint32_t nSYAudioBGMHyrule = 9;   // Hyrule Castle
+constexpr uint32_t nSYAudioBGMLast = 25;    // Final Destination
+constexpr uint32_t nSYAudioBGMZako = 36;    // Battlefield
+constexpr uint32_t nSYAudioBGMMetal = 37;   // Meta Crystal
+
+namespace {
+
+    const uint32_t kShufflePool[] = {
+        nSYAudioBGMPupupu,
+        nSYAudioBGMZebes,
+        nSYAudioBGMInishie,
+        nSYAudioBGMSector,
+        nSYAudioBGMJungle,
+        nSYAudioBGMCastle,
+        nSYAudioBGMYamabuki,
+        nSYAudioBGMYoster,
+        nSYAudioBGMHyrule,
+        nSYAudioBGMZako,
+        nSYAudioBGMMetal,
+        nSYAudioBGMLast
+    };
+
+    constexpr size_t kShufflePoolSize = sizeof(kShufflePool) / sizeof(kShufflePool[0]);
+
+    bool IsStageBGM(uint32_t bgm) {
+        for (size_t i = 0; i < kShufflePoolSize; i++) {
+            if (kShufflePool[i] == bgm) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+}
+
+// -1 means the user has not locked in a manual track
+extern "C" {
+    int32_t gManualMusicSelection = -1;
+}
+
+extern "C" uint32_t port_enhancement_shuffle_music(uint32_t requested_bgm) {
+    // 1. highest priority: Manual Selection via Double-Tap UI
+    if (gManualMusicSelection != -1) {
+        uint32_t chosen_track = (uint32_t)gManualMusicSelection;
+        gManualMusicSelection = -1; // Consume the selection so it doesn't loop
+        return chosen_track;
+    }
+
+    // 2. middle priority: Shuffle Music
+    if (CVarGetInteger(kShuffleMusicCVar, 0) != 0 && IsStageBGM(requested_bgm)) {
+        static bool sIsSeeded = false;
+        if (!sIsSeeded) {
+            // Seed the generator with the current time
+            std::srand(static_cast<unsigned int>(std::time(nullptr)));
+            sIsSeeded = true;
+        }
+        uint32_t random_index = std::rand() % kShufflePoolSize;
+        return kShufflePool[random_index];
+    }
+
+    // 3. lowest priority: Default Stage BGM
+    return requested_bgm;
+}
+
+namespace ssb64 {
+    namespace enhancements {
+        const char* ShuffleMusicCVarName() {
+            return kShuffleMusicCVar;
+        }
+    } // namespace enhancements
+} // namespace ssb64

--- a/port/enhancements/enhancements.h
+++ b/port/enhancements/enhancements.h
@@ -85,6 +85,8 @@ const char* NeutralSpawnsCVarName();
 const char* BootToVSCSSCVarName();
 const char* SkipResultsScreenCVarName();
 const char* CpuLevel9CVarName();
+const char* ShuffleMusicCVarName();
+const char* MusicSelectionCVarName();
 
 // Discord Rich Presence
 void UpdateDiscordPresence(const char* gameState, const char* matchDetails);

--- a/port/gui/PortMenu.cpp
+++ b/port/gui/PortMenu.cpp
@@ -1035,6 +1035,14 @@ void PortMenu::AddMenuSettings() {
         .CVar(ssb64::enhancements::CpuLevel9CVarName())
         .RaceDisable(false)
         .Options(CheckboxOptions().Tooltip("Automatically forces all CPU players to Level 9."));
+    AddWidget(path, "Shuffle Music", WIDGET_CVAR_CHECKBOX)
+        .CVar(ssb64::enhancements::ShuffleMusicCVarName())
+        .RaceDisable(false)
+        .Options(CheckboxOptions().Tooltip("Randomizes the BGM after a stage is chosen. Useful when enabling the competitive ruleset."));
+    AddWidget(path, "Add Music Selection Screen", WIDGET_CVAR_CHECKBOX)
+        .CVar(ssb64::enhancements::MusicSelectionCVarName())
+        .RaceDisable(false)
+        .Options(CheckboxOptions().Tooltip("Allows the player to pick a custom BGM track after the stage selection screen (music shuffling is ignored if this is turned on)."));
 
     // --- Input customization ---
     path.sidebarName = "Input";


### PR DESCRIPTION
https://github.com/user-attachments/assets/b6158cd7-de56-4042-8871-c148add5ab88

https://github.com/user-attachments/assets/c92aa33c-748f-4c1d-8694-257bab41f8ad

Allows the player to randomize the music track that's played on any given stage. Alternatively, allow the player to choose the music track after selecting a stage.

Decomp PR: https://github.com/JRickey/ssb-decomp-re/pull/8