### PR TITLE
Add character mod hook support

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -699,6 +699,10 @@ target_include_directories(ssb64_game PRIVATE
     ${CMAKE_CURRENT_SOURCE_DIR}/decomp/src       # Decomp game module headers
     ${CMAKE_CURRENT_SOURCE_DIR}/port             # Port headers (coroutine.h, etc.)
     ${CMAKE_CURRENT_SOURCE_DIR}/debug_tools      # Acmd trace (mixer.h calls acmd_trace_log_cmd)
+    # Event system headers: decomp PORT hooks fire engine events directly
+    # (hooks/Events.h -> ship/events/EventTypes.h + bridge/eventsbridge.h).
+    ${CMAKE_CURRENT_SOURCE_DIR}/libultraship/src
+    ${CMAKE_CURRENT_SOURCE_DIR}/libultraship/include
 )
 
 # Clang 16+ promoted several historically-warning diagnostics to errors by
@@ -826,6 +830,7 @@ target_include_directories(${PROJECT_NAME} PRIVATE
     ${CMAKE_CURRENT_SOURCE_DIR}/decomp/src       # Decomp game module headers (sys/, ft/, sc/, ...)
     ${CMAKE_CURRENT_SOURCE_DIR}/port
     ${CMAKE_CURRENT_SOURCE_DIR}/debug_tools
+    ${SSB64_CSS_GEN_DIR}                         # CSS icon baked headers (arrow_data.h)
 )
 if (NOT CMAKE_SYSTEM_NAME STREQUAL "Android")
     target_include_directories(${PROJECT_NAME} PRIVATE

--- a/port/bridge/lbreloc_bridge.cpp
+++ b/port/bridge/lbreloc_bridge.cpp
@@ -496,18 +496,46 @@ void lbRelocAddForceStatusBufferFile(u32 id, void *addr)
 // // // // // // // // // // // //
 
 /**
- * Load a file from the .o2r archive, copy into ram_dst, and perform
- * token-based internal + external pointer relocation.
+ * Copy `src_bytes` into `ram_dst` and perform the full reloc-fixup
+ * pipeline against it: cache evictions, byte-swap, status-buffer
+ * registration, internal/external pointer chain walks (token-based),
+ * figatree-specific cleanup, audit emission.
  *
- * Instead of writing 64-bit void* into 4-byte slots (which would corrupt
- * adjacent data), we register each target pointer in the token table and
- * write the 32-bit token into the slot.
+ * Exposed for mod-loader use: a mod that ships its own reloc-format
+ * file bytes (e.g., new-character assets bundled inside a TCC mod)
+ * calls this directly instead of routing through portLoadRelocResource,
+ * which only sees files inside BattleShip.o2r. Mod file_ids may sit
+ * outside the vanilla 0..RELOC_FILE_COUNT-1 range; we gate operations
+ * that need a valid gRelocFileTable[] entry on the usual bounds check.
+ *
+ * Token-based relocation: instead of writing 64-bit void* into 4-byte
+ * slots (which would corrupt adjacent data on LP64), each target
+ * pointer is registered in the token table and the 32-bit token is
+ * written into the 4-byte slot.
  */
-void lbRelocLoadAndRelocFile(u32 file_id, void *ram_dst, u32 bytes_num, s32 loc)
+extern "C" void portRelocLoadFileFromBytes(
+	unsigned int    file_id,
+	void           *ram_dst,
+	unsigned int    bytes_num,
+	int             loc,
+	const void     *src_bytes,
+	unsigned int    src_size,
+	unsigned short  reloc_intern_offset,
+	unsigned short  reloc_extern_offset,
+	const unsigned short *extern_file_ids,
+	unsigned int    extern_count,
+	int             force_figatree_fixup)
 {
-	auto relocFile = portLoadRelocResource(file_id);
-	bool is_fighter_figatree = portRelocIsFighterFigatreeFile(file_id);
+	/* portRelocIsFighterFigatreeFile looks up gRelocFileTable[file_id]
+	 * to match the "reloc_animations/" path prefix. Mod-registered file
+	 * IDs sit outside the vanilla table range so the path lookup fails
+	 * and the halfswap step is skipped, leaving anim-joint tokens in
+	 * chain-entry form. The mod can override via force_figatree_fixup
+	 * for its own animation files. */
+	bool is_fighter_figatree =
+		force_figatree_fixup || portRelocIsFighterFigatreeFile(file_id);
 	std::vector<uint8_t> figatree_reloc_words;
+	const char *table_path = (file_id < RELOC_FILE_COUNT) ? gRelocFileTable[file_id] : nullptr;
 
 	// Gated: SSB64_LOG_LBRELOC_LOAD=1 logs every file load. Helpful when
 	// tracing which reloc files are loaded per scene.
@@ -517,19 +545,19 @@ void lbRelocLoadAndRelocFile(u32 file_id, void *ram_dst, u32 bytes_num, s32 loc)
 			s_load_log_count++;
 			port_log("SSB64: lbReloc LOAD file_id=%u loc=%d path=%s fig=%d\n",
 				file_id, loc,
-				(file_id < RELOC_FILE_COUNT && gRelocFileTable[file_id]) ? gRelocFileTable[file_id] : "(null)",
+				table_path ? table_path : "(null)",
 				(int)is_fighter_figatree);
 		}
 	}
 
-	if (!relocFile)
+	if (src_bytes == nullptr || src_size == 0)
 	{
-		spdlog::error("lbReloc bridge: cannot load file_id {} — halting", file_id);
+		spdlog::error("portRelocLoadFileFromBytes: NULL/empty src for file_id {}", file_id);
 		return;
 	}
 
 	// Copy decompressed data into the game's heap allocation
-	size_t copySize = relocFile->Data.size();
+	size_t copySize = src_size;
 	if (copySize > bytes_num && bytes_num > 0)
 	{
 		spdlog::warn("lbReloc bridge: file_id {} data ({} bytes) exceeds "
@@ -564,7 +592,24 @@ void lbRelocLoadAndRelocFile(u32 file_id, void *ram_dst, u32 bytes_num, s32 loc)
 	extern void portPackedDisplayListCacheDeleteRange(const void *base, size_t size);
 	portPackedDisplayListCacheDeleteRange(ram_dst, copySize);
 	portRelocEvictFileRangesInRange(ram_dst, copySize);
-	memcpy(ram_dst, relocFile->Data.data(), copySize);
+	memcpy(ram_dst, src_bytes, copySize);
+
+	/* lbRelocGetExternHeapFile sets sLBRelocExternFileHeap = heap so that
+	 * subsequent dep loads (triggered by the chain walk via
+	 * lbRelocGetExternBufferFile) bump-allocate sequentially past this
+	 * file's buffer. Mod-loaded files bypass that entry point entirely,
+	 * leaving the bump pointer at whatever the last vanilla load left it
+	 * at -- often pointing *into* the buffer we just memcpy'd. When a
+	 * cache-miss dep load fires inside the chain walk it then writes its
+	 * bytes through this file's region, corrupting slots before the walk
+	 * has a chance to tokenize them. Mirror the vanilla setup by
+	 * advancing the bump pointer past this file's end so dep allocations
+	 * land in clean memory. Done for Extern and Force; Default uses the
+	 * intern-buffer bump heap which mod paths never enter. */
+	if (loc == nLBFileLocationExtern || loc == nLBFileLocationForce) {
+		sLBRelocExternFileHeap = (void *)LBRELOC_CACHE_ALIGN(
+			(uintptr_t)ram_dst + copySize);
+	}
 
 	// One-shot raw dump for verification against ROM extraction.
 	// Set SSB64_DUMP_FILE_ID env var to a file_id; this writes the post-memcpy,
@@ -592,7 +637,7 @@ void lbRelocLoadAndRelocFile(u32 file_id, void *ram_dst, u32 bytes_num, s32 loc)
 				fwrite(ram_dst, 1, copySize, df);
 				fclose(df);
 				spdlog::info("[port-dump] wrote {} bytes for file_id={} ({}) to {}",
-				             copySize, file_id, gRelocFileTable[file_id], path);
+				             copySize, file_id, table_path ? table_path : "(mod)", path);
 			}
 		}
 	}
@@ -612,14 +657,12 @@ void lbRelocLoadAndRelocFile(u32 file_id, void *ram_dst, u32 bytes_num, s32 loc)
 		lbRelocAddStatusBufferFile(file_id, ram_dst);
 	}
 
-	sPortRelocFileRanges.push_back({ reinterpret_cast<uintptr_t>(ram_dst), copySize, file_id, gRelocFileTable[file_id] });
+	sPortRelocFileRanges.push_back({ reinterpret_cast<uintptr_t>(ram_dst), copySize, file_id, table_path });
 
 	/* Mirror this range into the DL-range registry so gfx_step's bounds
 	 * check accepts DLs resolved through reloc files. Path string from
 	 * gRelocFileTable is static (linker-emitted), safe to retain. */
-	port_dl_range_register(ram_dst, copySize,
-	                       (file_id < RELOC_FILE_COUNT && gRelocFileTable[file_id])
-	                       ? gRelocFileTable[file_id] : "reloc?");
+	port_dl_range_register(ram_dst, copySize, table_path ? table_path : "reloc?");
 
 	// --- Internal pointer relocation (token-based) ---
 	//
@@ -631,7 +674,7 @@ void lbRelocLoadAndRelocFile(u32 file_id, void *ram_dst, u32 bytes_num, s32 loc)
 	// In the port, we compute the pointer, register it as a token, and
 	// write the 32-bit token into the 4-byte word.
 
-	u16 reloc_intern = relocFile->RelocInternOffset;
+	u16 reloc_intern = reloc_intern_offset;
 
 	while (reloc_intern != 0xFFFF)
 	{
@@ -685,7 +728,7 @@ void lbRelocLoadAndRelocFile(u32 file_id, void *ram_dst, u32 bytes_num, s32 loc)
 	// The extern file IDs come from the RelocFile metadata (extracted
 	// by Torch at ROM-extraction time), not from ROM DMA.
 
-	u16 reloc_extern = relocFile->RelocExternOffset;
+	u16 reloc_extern = reloc_extern_offset;
 	u32 extern_idx = 0;
 
 	while (reloc_extern != 0xFFFF)
@@ -695,15 +738,15 @@ void lbRelocLoadAndRelocFile(u32 file_id, void *ram_dst, u32 bytes_num, s32 loc)
 		u16 next_reloc = (u16)(*slot >> 16);
 		u16 words_num  = (u16)(*slot & 0xFFFF);
 
-		if (extern_idx >= relocFile->ExternFileIds.size())
+		if (extern_idx >= extern_count)
 		{
 			spdlog::error("lbReloc bridge: file_id {} extern reloc overrun "
 			              "(idx={}, count={})", file_id, extern_idx,
-			              relocFile->ExternFileIds.size());
+			              extern_count);
 			break;
 		}
 
-		u16 dep_file_id = relocFile->ExternFileIds[extern_idx];
+		u16 dep_file_id = extern_file_ids[extern_idx];
 		void *vaddr_extern;
 
 		// Check if dependency is already loaded
@@ -759,10 +802,135 @@ void lbRelocLoadAndRelocFile(u32 file_id, void *ram_dst, u32 bytes_num, s32 loc)
 	{
 		extern void portStageAuditEmitLoadSummary(unsigned int file_id, const char *path, size_t size);
 		extern void portStageAuditEmitOpcodeCensus(unsigned int file_id, const char *path, const void *data, size_t size);
-		const char *audit_path = (file_id < RELOC_FILE_COUNT) ? gRelocFileTable[file_id] : nullptr;
-		portStageAuditEmitLoadSummary(file_id, audit_path, copySize);
-		portStageAuditEmitOpcodeCensus(file_id, audit_path, ram_dst, copySize);
+		portStageAuditEmitLoadSummary(file_id, table_path, copySize);
+		portStageAuditEmitOpcodeCensus(file_id, table_path, ram_dst, copySize);
 	}
+}
+
+/**
+ * Mod-private variant of portRelocLoadFileFromBytes: copies src_bytes
+ * into a mod-owned buffer, byte-swaps to native endian, and walks the
+ * intern reloc chain to register pointer tokens. Skips status-buffer
+ * registration, extern chain walks, cache evictions, and audit emission
+ * because the caller's buffer isn't shared with the engine's per-scene
+ * heap (so engine cache invariants don't apply, and consuming a slot in
+ * the per-scene status buffer would steal it from the engine's own
+ * file loads). Used by mods (via ce_load_reloc_blob) to host long-lived
+ * reloc files (e.g., SR-extended menu sprite blobs) that need to flow
+ * through the engine's reloc pipeline so internal pointer tokens
+ * resolve, but don't belong in the engine's per-scene file table.
+ *
+ * Re-entrant safety: callable from inside lbRelocInitSetup's tail (e.g.,
+ * via the CharacterEngine post-reset callback) because nothing here
+ * touches lbRelocInternBuffer or other per-scene engine state.
+ */
+extern "C" void portRelocLoadFileFromBytesPrivate(
+	void           *ram_dst,
+	unsigned int    dst_size,
+	const void     *src_bytes,
+	unsigned int    src_size,
+	unsigned short  reloc_intern_offset)
+{
+	if (src_bytes == nullptr || src_size == 0 || ram_dst == nullptr) {
+		return;
+	}
+
+	size_t copySize = src_size;
+	if (copySize > dst_size && dst_size > 0) {
+		spdlog::warn("portRelocLoadFileFromBytesPrivate: src ({} bytes) > dst ({} bytes), truncating",
+		             copySize, dst_size);
+		copySize = dst_size;
+	}
+
+	// Invalidate any prior fixup state / cached uploads that still reference
+	// the buffer we're about to overwrite. Each call must redo
+	// portFixupSprite / portFixupBitmapArray / portFixupSpriteBitmapData on
+	// the freshly-loaded data; without these evictions the fixup tracker
+	// thinks "already done" and skips the BE-restore + TMEM swizzle, leaving
+	// the texel data in the wrong byte order for the RDP.
+	portEvictStructFixupsInRange(ram_dst, copySize);
+	extern void portTextureCacheDeleteRange(const void *base, size_t size);
+	portTextureCacheDeleteRange(ram_dst, copySize);
+	extern void portPackedDisplayListCacheDeleteRange(const void *base, size_t size);
+	portPackedDisplayListCacheDeleteRange(ram_dst, copySize);
+
+	memcpy(ram_dst, src_bytes, copySize);
+
+	// Byte-swap from N64 BE to native LE; same call portRelocLoadFileFromBytes
+	// makes inside its public path. file_id is unused by the swap logic for
+	// non-figatree files but the API requires a value; pass 0 since this is
+	// a mod-private buffer that has no engine file_id.
+	portRelocByteSwapBlob(ram_dst, copySize, /* file_id = */ 0u);
+
+	// Register the buffer's address range so portRelocFindContainingFile can
+	// see it. Display lists inside a reloc file encode their vertex / matrix /
+	// sub-DL pointers as segment-0x0E offsets (0x0E0xxxxx). Those only get
+	// rewritten to fileBase+offset by portNormalizeDisplayListPointer, which
+	// bails immediately unless the DL pointer resolves to a registered range.
+	// The public loader pushes the range above; the private path used
+	// to skip it, so a mod-private DL (e.g. KirbyHatEngine's 0xA8D custom-hat
+	// models) was never widened — the interpreter read the packed 8-byte
+	// commands as native 16-byte and fed the raw 0x0Exxxxxx vertex pointer to
+	// GfxSpVertex, AV'ing on a garbage host address. Re-loads reuse the same
+	// buffer, so evict any prior range for this region before re-registering.
+	portRelocEvictFileRangesInRange(ram_dst, copySize);
+	sPortRelocFileRanges.push_back({ reinterpret_cast<uintptr_t>(ram_dst),
+	                                 copySize, /* file_id = */ 0xFFFFFFFFu,
+	                                 "(mod-private)" });
+
+	/* Mirror into the DL-range registry as the public path does, so
+	 * gfx_step's runaway-walker bounds check accepts mod-private DLs
+	 * (portRelocEvictFileRangesInRange above also unregisters any prior
+	 * DL range for this buffer, so re-loads must re-register). */
+	port_dl_range_register(ram_dst, copySize, "(mod-private)");
+
+	// Intern chain walk: each chain entry is a u32 holding [next_offset_words][target_offset_words];
+	// register a token for the in-file target pointer and stamp the token
+	// into the slot. Same logic as portRelocLoadFileFromBytes' intern walk
+	// but without texture-fixup (no SETTIMG-driven texture cache for the
+	// mod-private buffer) and without figatree halfswap.
+	u16 reloc_intern = reloc_intern_offset;
+	while (reloc_intern != 0xFFFF) {
+		u32 *slot = (u32 *)((uintptr_t)ram_dst + (reloc_intern * sizeof(u32)));
+		u16 next_reloc = (u16)(*slot >> 16);
+		u16 words_num  = (u16)(*slot & 0xFFFF);
+
+		void *target = (void *)((uintptr_t)ram_dst + (words_num * sizeof(u32)));
+		u32 token = portRelocRegisterPointer(target);
+		*slot = token;
+
+		reloc_intern = next_reloc;
+	}
+}
+
+/**
+ * Load a file from the .o2r archive, copy into ram_dst, and perform
+ * token-based internal + external pointer relocation. Thin wrapper
+ * around portRelocLoadFileFromBytes that sources its bytes via the
+ * libultraship ResourceManager (i.e., the BattleShip.o2r /
+ * BattleShip.fromsource.o2r pipeline).
+ */
+void lbRelocLoadAndRelocFile(u32 file_id, void *ram_dst, u32 bytes_num, s32 loc)
+{
+	auto relocFile = portLoadRelocResource(file_id);
+	if (!relocFile)
+	{
+		spdlog::error("lbReloc bridge: cannot load file_id {} — halting", file_id);
+		return;
+	}
+
+	portRelocLoadFileFromBytes(
+		(unsigned int)file_id,
+		ram_dst,
+		bytes_num,
+		(int)loc,
+		relocFile->Data.data(),
+		(unsigned int)relocFile->Data.size(),
+		relocFile->RelocInternOffset,
+		relocFile->RelocExternOffset,
+		relocFile->ExternFileIds.data(),
+		(unsigned int)relocFile->ExternFileIds.size(),
+		/* force_figatree_fixup = */ 0);
 }
 
 // // // // // // // // // // // //
@@ -897,6 +1065,40 @@ void* lbRelocGetForceExternHeapFile(u32 id, void *heap)
 	sLBRelocExternFileHeap = heap;
 	sLBRelocInternBuffer.force_status_buffer_num = 0;
 	return lbRelocGetForceExternBufferFile(id);
+}
+
+/* Mod helper: same force-status-buffer reset that
+ * lbRelocGetForceExternHeapFile does on entry. Mods that route mod-
+ * registered anim file IDs through portRelocLoadFileFromBytes (skipping
+ * the orig wrapper because the file isn't in the engine's file table)
+ * still need this reset, otherwise the lbRelocAddForceStatusBufferFile
+ * call inside portRelocLoadFileFromBytes accumulates entries across
+ * fighter status changes until the per-scene cap is exceeded and the
+ * engine enters its "Force Status Buffer is full !!" panic loop. */
+extern "C" void portRelocResetForceStatusBuffer(void)
+{
+	sLBRelocInternBuffer.force_status_buffer_num = 0;
+}
+
+/* Accessors for the extern-file bump cursor. portRelocLoadFileFromBytes
+ * resets sLBRelocExternFileHeap to point past the file it just loaded
+ * so that file's own extern deps bump-allocate contiguously
+ * after it. That's correct when the destination is the engine's shared
+ * extern heap, but when a mod loads a file into its own malloc'd buffer
+ * (CharacterEngine's private-buffer hooks) the reset leaves the cursor
+ * pointing *inside* that private buffer. If the OUTER file's chain walk
+ * then loads a later vanilla dep, it bump-allocates into the small
+ * private buffer and overruns it. CharacterEngine brackets each private
+ * mod-file load with get/set so the outer walk's cursor survives the
+ * nested load. */
+extern "C" void *portRelocGetExternFileHeap(void)
+{
+	return sLBRelocExternFileHeap;
+}
+
+extern "C" void portRelocSetExternFileHeap(void *heap)
+{
+	sLBRelocExternFileHeap = heap;
 }
 
 // // // // // // // // // // // //

--- a/port/fighter_registry.cpp
+++ b/port/fighter_registry.cpp
@@ -1,0 +1,385 @@
+/**
+ * fighter_registry.cpp - storage + accessors for the per-fkind dispatch
+ * registry declared in fighter_registry.h.
+ *
+ * Vector-backed, one row per fkind. Vanilla rows seeded at boot from
+ * decomp arrays via port_fighter_seed_vanilla (implemented decomp-side in
+ * decomp/src/ft/ftport.c, which has access to the source arrays + types).
+ * Synth rows registered by character mods at MOD_INIT.
+ */
+
+#include "fighter_registry.h"
+
+#include <cstring>
+#include <memory>
+#include <vector>
+
+namespace {
+
+using FDPtr = std::unique_ptr<FighterDescriptor>;
+std::vector<FDPtr> sRegistry;
+
+/* Returns the row for fkind, or nullptr if out of range / unregistered. */
+const FighterDescriptor *get(int fkind)
+{
+    if (fkind < 0) return nullptr;
+    if (static_cast<size_t>(fkind) >= sRegistry.size()) return nullptr;
+    return sRegistry[static_cast<size_t>(fkind)].get();
+}
+
+} /* namespace */
+
+extern "C" {
+
+void port_fighter_register(int fkind, const FighterDescriptor *src)
+{
+    if (fkind < 0 || src == nullptr) return;
+
+    if (static_cast<size_t>(fkind) >= sRegistry.size()) {
+        sRegistry.resize(static_cast<size_t>(fkind) + 1);
+    }
+
+    auto row = std::make_unique<FighterDescriptor>();
+    std::memcpy(row.get(), src, sizeof(FighterDescriptor));
+    sRegistry[static_cast<size_t>(fkind)] = std::move(row);
+}
+
+const FighterDescriptor *port_fighter_descriptor(int fkind)
+{
+    return get(fkind);
+}
+
+struct FTData *port_fighter_data(int fkind)
+{
+    if (const auto *r = get(fkind)) return r->ft_data;
+    return nullptr;
+}
+
+struct FTStatusDesc *port_fighter_special_descs(int fkind)
+{
+    if (const auto *r = get(fkind)) return r->special_descs;
+    return nullptr;
+}
+
+int port_fighter_special_descs_count(int fkind)
+{
+    if (const auto *r = get(fkind)) return r->special_descs_count;
+    return 0;
+}
+
+PortFTSpecialEnterFn port_fighter_special_handler(int fkind, int kind)
+{
+    if (kind < 0 || kind >= PORT_FIGHTER_SPECIAL_COUNT) return nullptr;
+
+    if (const auto *r = get(fkind)) return r->special_handler[kind];
+    return nullptr;
+}
+
+/* nFTCommonStatusEntryNull is the safe sentinel for "no entry animation"
+ * (decomp value: 1). Hard-coded so the header stays decomp-agnostic. */
+static constexpr int PORT_ENTRY_NULL_STATUS = 1;
+
+int port_fighter_entry_appear(int fkind, int entry_id)
+{
+    if (entry_id != 0 && entry_id != 1) return PORT_ENTRY_NULL_STATUS;
+    if (const auto *r = get(fkind)) return r->entry_appear_status[entry_id];
+    return PORT_ENTRY_NULL_STATUS;
+}
+
+void port_fighter_entry_make_effect(int fkind, struct FTStruct *fp)
+{
+    if (const auto *r = get(fkind)) {
+        if (r->entry_make_effect != nullptr) r->entry_make_effect(fp);
+    }
+}
+
+struct FTOpeningDesc *port_fighter_opening_descs(int fkind)
+{
+    if (const auto *r = get(fkind)) return r->opening_descs;
+    return nullptr;
+}
+
+struct FTCostume *port_fighter_costume_row(int fkind)
+{
+    if (const auto *r = get(fkind)) return r->costume_row;
+    return nullptr;
+}
+
+float port_fighter_scale(int fkind)
+{
+    if (const auto *r = get(fkind)) return r->scale;
+    return 1.0f;
+}
+
+int port_fighter_skeleton_col_anim_base(int fkind)
+{
+    if (const auto *r = get(fkind)) return r->skeleton_col_anim_base;
+    return 0;
+}
+
+int port_fighter_down_bounce_fgm(int fkind)
+{
+    if (const auto *r = get(fkind)) return r->down_bounce_fgm;
+    return 0;
+}
+
+int port_fighter_public_call_fgm(int fkind)
+{
+    if (const auto *r = get(fkind)) return r->public_call_fgm;
+    return 0;
+}
+
+void *port_fighter_yoshi_egg_damage_coll(int fkind)
+{
+    if (const auto *r = get(fkind)) return r->yoshi_egg_damage_coll;
+    return nullptr;
+}
+
+void *port_fighter_computer_attack_list(int fkind)
+{
+    if (const auto *r = get(fkind)) return r->computer_attack_list;
+    return nullptr;
+}
+
+void port_fighter_for_each(PortFighterForEachFn cb, void *user)
+{
+    if (cb == nullptr) return;
+    for (size_t i = 0; i < sRegistry.size(); ++i) {
+        if (sRegistry[i] != nullptr) {
+            cb(static_cast<int>(i), sRegistry[i].get(), user);
+        }
+    }
+}
+
+/* SR engine-extension accessors. Each looks up the fkind row and falls
+ * back to a safe sentinel (0 / NULL / safe int) when no override is
+ * registered. */
+
+int port_fighter_shield_hitlag_skip(int fkind, struct GObj *fighter_gobj, int status_id)
+{
+    if (const auto *r = get(fkind)) {
+        if (r->shield_hitlag_skip != nullptr) {
+            return r->shield_hitlag_skip(fighter_gobj, status_id);
+        }
+    }
+    return 0;
+}
+
+int port_fighter_ecb_override(struct FTStruct *fp, int next_status_id,
+                               float *out_upper, float *out_middle)
+{
+    if (fp == nullptr || out_upper == nullptr || out_middle == nullptr) return 0;
+    for (size_t i = 0; i < sRegistry.size(); ++i) {
+        const FighterDescriptor *r = sRegistry[i].get();
+        if (r == nullptr) continue;
+        if (r->ecb_override == nullptr) continue;
+        if (r->ecb_override(fp, next_status_id, out_upper, out_middle)) {
+            return 1;
+        }
+    }
+    return 0;
+}
+
+int port_fighter_kirby_hat_id(int fkind)
+{
+    if (const auto *r = get(fkind)) return r->kirby_hat_id;
+    return 0;
+}
+
+/* Per-player pending custom hat id storage lives in KirbyHatEngine. These
+ * forward through handlers the mod installs at MOD_INIT. */
+static PortKirbySetPendingHatFn s_set_pending = nullptr;
+static PortKirbyGetPendingHatFn s_get_pending = nullptr;
+
+void port_kirby_register_pending_hat_handlers(PortKirbySetPendingHatFn set,
+                                              PortKirbyGetPendingHatFn get)
+{
+    s_set_pending = set;
+    s_get_pending = get;
+}
+
+void port_kirby_set_pending_hat(int player, int hat_id)
+{
+    if (s_set_pending) s_set_pending(player, hat_id);
+}
+
+int port_kirby_get_pending_hat(int player)
+{
+    return s_get_pending ? s_get_pending(player) : 0;
+}
+
+/* -1 = unset; ftMainSetStatus then uses the acting fighter's own fkind. Scoped
+ * to a single synth-copied-special SetStatus call by the dispatch select fn. */
+static int sKirbyCopySpecialFkind = -1;
+
+void port_kirby_set_copy_special_fkind(int fkind)
+{
+    sKirbyCopySpecialFkind = fkind;
+}
+
+int port_kirby_get_copy_special_fkind(void)
+{
+    return sKirbyCopySpecialFkind;
+}
+
+int port_fighter_crowd_chant_fgm(int fkind)
+{
+    if (const auto *r = get(fkind)) return r->crowd_chant_fgm;
+    return 0;
+}
+
+const char *port_fighter_action_string(int fkind, int action_id)
+{
+    const auto *r = get(fkind);
+    if (r == nullptr) return nullptr;
+    if (r->action_string_table == nullptr) return nullptr;
+    int idx = action_id - r->action_string_base_action_id;
+    if (idx < 0 || idx >= r->action_string_table_count) return nullptr;
+    return r->action_string_table[idx];
+}
+
+void *port_fighter_ai_attack_prevent_routine(int fkind)
+{
+    if (const auto *r = get(fkind)) return r->ai_attack_prevent_routine;
+    return nullptr;
+}
+
+void *port_fighter_ai_recovery_routine(int fkind)
+{
+    if (const auto *r = get(fkind)) return r->ai_recovery_routine;
+    return nullptr;
+}
+
+void *port_fighter_ai_attack_weight_routine(int fkind)
+{
+    if (const auto *r = get(fkind)) return r->ai_attack_weight_routine;
+    return nullptr;
+}
+
+int port_fighter_remix_1p_end_bgm(int fkind)
+{
+    if (const auto *r = get(fkind)) return r->remix_1p_end_bgm;
+    return 0;
+}
+
+int port_fighter_remix_1p_ending_image_file_id(int fkind)
+{
+    if (const auto *r = get(fkind)) return r->remix_1p_ending_image_file_id;
+    return 0;
+}
+
+const unsigned char *port_fighter_default_costumes(int fkind, int *out_count)
+{
+    if (const auto *r = get(fkind)) {
+        if (out_count != nullptr) *out_count = r->default_costumes_count;
+        return r->default_costumes;
+    }
+    if (out_count != nullptr) *out_count = 0;
+    return nullptr;
+}
+
+int port_fighter_team_costume(int fkind, int team)
+{
+    if (team < 0 || team >= 4) return -1;
+    if (const auto *r = get(fkind)) {
+        unsigned char c = r->team_costume[team];
+        return (c == 0xFFu) ? -1 : (int)c;
+    }
+    return -1;
+}
+
+const unsigned char *port_fighter_charge_smash_frames(int fkind)
+{
+    if (const auto *r = get(fkind)) return r->charge_smash_frames;
+    return nullptr;
+}
+
+int port_fighter_costume_count(int fkind)
+{
+    if (const auto *r = get(fkind)) return r->costume_count;
+    return 0;
+}
+
+float port_fighter_css_spotlight_scale(int fkind)
+{
+    if (const auto *r = get(fkind)) {
+        if (r->css_spotlight_scale > 0.0f) return r->css_spotlight_scale;
+    }
+    return 1.5f;
+}
+
+int port_fighter_custom_capture_action(int fkind)
+{
+    if (const auto *r = get(fkind)) return r->custom_capture_action;
+    return 0;
+}
+
+int port_fighter_custom_capture_dk_interrupt(int fkind, struct FTStruct *grabber_fp)
+{
+    if (const auto *r = get(fkind)) {
+        if (r->custom_capture_dk_interrupt != nullptr) {
+            return r->custom_capture_dk_interrupt(grabber_fp);
+        }
+    }
+    return 0;
+}
+
+int port_fighter_results_announce_fgm(int fkind)
+{
+    if (const auto *r = get(fkind)) return r->results_announce_fgm;
+    return 0;
+}
+
+const char *port_fighter_results_name(int fkind)
+{
+    if (const auto *r = get(fkind)) return r->results_name;
+    return nullptr;
+}
+
+float port_fighter_results_name_lx(int fkind)
+{
+    if (const auto *r = get(fkind)) return r->results_name_lx;
+    return 0.0f;
+}
+
+float port_fighter_results_name_scale(int fkind)
+{
+    if (const auto *r = get(fkind)) return r->results_name_scale;
+    return 1.0f;
+}
+
+float port_fighter_results_wins_lx(int fkind)
+{
+    if (const auto *r = get(fkind)) return r->results_wins_lx;
+    return 0.0f;
+}
+
+/* CE-owned FTEmblemModels blob base, refreshed every scene reset. The emblem
+ * model's internal Gfx/Vtx/texture pointer tokens are wiped + re-registered on
+ * each lbRelocInitSetup, so the base buffer pointer is stable but the resolved
+ * model is only valid after CE has reloaded for the current generation. CE
+ * passes NULL here if the reload failed, which disables the emblem draw. */
+static void *s_results_emblem_base = nullptr;
+
+void port_set_results_emblem_base(void *base)
+{
+    s_results_emblem_base = base;
+}
+
+int port_fighter_results_emblem(int fkind, void **out_dobjdesc,
+                                void **out_mobjsub, void **out_matanim)
+{
+    const auto *r = get(fkind);
+    if (r == nullptr || r->results_emblem_valid == 0 ||
+        s_results_emblem_base == nullptr)
+    {
+        return 0;
+    }
+    unsigned char *base = static_cast<unsigned char *>(s_results_emblem_base);
+    if (out_dobjdesc) *out_dobjdesc = base + r->results_emblem_dobjdesc;
+    if (out_mobjsub)  *out_mobjsub  = base + r->results_emblem_mobjsub;
+    if (out_matanim)  *out_matanim  = base + r->results_emblem_matanim;
+    return 1;
+}
+
+} /* extern "C" */

--- a/port/fighter_registry.h
+++ b/port/fighter_registry.h
@@ -1,0 +1,349 @@
+/**
+ * fighter_registry.h - port-side per-fighter dispatch table.
+ *
+ * Decomp tables like dFTManagerDataFiles[] / dFTMainSpecialStatusDescs[] /
+ * dFTCommonSpecialNStatusList[] are sized for the 27 vanilla FTKind values.
+ * Synth fighters added by character mods (Crash, Banjo, etc.) have fkind
+ * values past nFTKindEnumCount, so any unredirected `dFooArr[fkind]` site
+ * OOBs and either crashes or pulls in adjacent data.
+ *
+ * This registry is the single redirection point. Every per-fkind dispatch
+ * site in the decomp gets PORT-gated to read through one of the accessors
+ * below. Vanilla rows are seeded once at boot from the decomp arrays; mods
+ * call port_fighter_register() at MOD_INIT to add synth rows.
+ */
+
+#ifndef PORT_FIGHTER_REGISTRY_H
+#define PORT_FIGHTER_REGISTRY_H
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/* Forward declarations of decomp types. Opaque from the registry's
+ * perspective; full defs live under decomp/include/. */
+struct FTData;
+struct FTStatusDesc;
+struct FTOpeningDesc;
+struct FTCostume;
+struct GObj;
+struct FTStruct;
+
+typedef void (*PortFTSpecialEnterFn)(struct GObj *);
+typedef void (*PortFTEntryMakeEffectFn)(struct FTStruct *);
+/* Per-fighter shield-hitlag override hook. Returns nonzero to zero the
+ * fighter's hitlag_tics when a shielded hit lands (SR Crash's NSPBlocked
+ * skip-hitlag pattern, CrashSpecial.asm shield_hitlag_patch_).
+ * status_id is the fighter's current action; handlers match against
+ * their character-specific blocked-NSP action ids. */
+typedef int  (*PortFTShieldHitlagSkipFn)(struct GObj *, int status_id);
+/* Per-fighter ECB resize hook. Engine calls this from ftMainSetStatus
+ * just before the new action's ECB upper/middle radii get loaded so the
+ * mod can substitute custom sizes (SR Crash dig_ecb_patch_ shrinks the
+ * collision box while underground). Returns 1 if the descriptor wrote
+ * new sizes via the two output args, 0 to leave the engine's defaults
+ * alone. */
+typedef int  (*PortFTECBOverrideFn)(struct FTStruct *fp, int next_status_id,
+                                     float *out_upper, float *out_middle);
+/* SR CustomGrabAction.asm capture_dk_break_fix_: per-grabber override for the
+ * ThrownDK mash/break-out interrupt. Called from ftCommonCaptureShoulderedProcInterrupt
+ * with the GRABBING fighter's struct (the SR patch loads a2 = grabbing player struct
+ * before jalr). Return nonzero to skip the whole break-out routine (the grabbed
+ * opponent can't mash free), 0 to run vanilla. Wario's always returns 1; Marina's
+ * (not in roster) gates on the grabber's ThrowF action. */
+typedef int  (*PortFTCaptureDkInterruptFn)(struct FTStruct *grabber_fp);
+
+enum {
+    PORT_FIGHTER_SPECIAL_N      = 0,
+    PORT_FIGHTER_SPECIAL_HI     = 1,
+    PORT_FIGHTER_SPECIAL_LW     = 2,
+    PORT_FIGHTER_SPECIAL_AIR_N  = 3,
+    PORT_FIGHTER_SPECIAL_AIR_HI = 4,
+    PORT_FIGHTER_SPECIAL_AIR_LW = 5,
+    PORT_FIGHTER_SPECIAL_COUNT  = 6
+};
+
+enum {
+    PORT_FIGHTER_ENTRY_APPEAR_R = 0,
+    PORT_FIGHTER_ENTRY_APPEAR_L = 1
+};
+
+typedef struct FighterDescriptor {
+    /* Files */
+    struct FTData               *ft_data;
+
+    /* Specials: per-fkind status descs (read at action_id >= 0xDC),
+     * plus per-fkind enter handlers (N / Hi / Lw, ground + air). */
+    struct FTStatusDesc         *special_descs;
+    int                          special_descs_count;
+    PortFTSpecialEnterFn         special_handler[PORT_FIGHTER_SPECIAL_COUNT];
+
+    /* Match entry (status id picked at start of round + per-fkind effect). */
+    int                          entry_appear_status[2];   /* [R, L] */
+    PortFTEntryMakeEffectFn      entry_make_effect;        /* NULL = no effect */
+
+    /* Opening / cutscene descs (per-fkind row pointer from the ovl1
+     * D_ovl1_80390D20 table). */
+    struct FTOpeningDesc        *opening_descs;
+
+    /* Costumes (struct holds royal[4] / team[3] / develop). */
+    struct FTCostume            *costume_row;
+
+    /* Combat / damage */
+    float                        scale;
+    int                          skeleton_col_anim_base;
+
+    /* Specific eats (Yoshi egg damage collision) */
+    void                        *yoshi_egg_damage_coll;
+
+    /* SFX */
+    int                          down_bounce_fgm;
+    int                          public_call_fgm;
+
+    /* CPU */
+    void                        *computer_attack_list;
+
+    /* CSS presentation */
+    int                          css_motion_special;
+    void                        *css_attack1_motion_descs;
+
+    /* CSS flashing-spotlight scale. The mnPlayers*SpotlightProcUpdate sizes[]
+     * tables are 12-wide, so synth fkinds read this instead. 0 = unset; the
+     * accessor falls back to 1.5 (every vanilla fighter except DK). */
+    float                        css_spotlight_scale;
+
+    /* Per-fighter SR-engine extension callbacks. NULL = no override. */
+    PortFTShieldHitlagSkipFn     shield_hitlag_skip;
+    PortFTECBOverrideFn          ecb_override;
+
+    /* SR Crash.asm:666-668: Kirby inhale-copy hat id. 0 = no special id
+     * (fighter doesn't grant a special Kirby hat). */
+    int                          kirby_hat_id;
+
+    /* SR Crash.asm:671-673: crowd_chant FGM id (announcer chants character
+     * name on rally hit). 0 = use parent's default chant. */
+    int                          crowd_chant_fgm;
+
+    /* SR Crash.asm:676-678: per-action display-name string table. NULL =
+     * no table (training-mode action overlay falls back to parent). */
+    const char *const           *action_string_table;
+    int                          action_string_table_count;
+    int                          action_string_base_action_id;
+
+    /* SR Crash.asm:714-717: AI attack-prevent routine ptr. NULL = use
+     * parent's. Signature: int(*)(struct FTStruct*, int input_kind) -
+     * returns nonzero to skip committing that attack (SR sets t2=1). */
+    void                        *ai_attack_prevent_routine;
+
+    /* SR Crash/AI/Attacks.asm recovery_logic: per-fkind CPU recovery hook
+     * fired right after ftComputerFollowObjectiveWalk in the Recover
+     * objective (SR custom_recovery_logic @0x80137FBC). NULL = parent's.
+     * Signature: void(*)(struct FTStruct*). */
+    void                        *ai_recovery_routine;
+
+    /* SR Crash/AI/Attacks.asm cpu_attack_weight: per-fkind hook to adjust
+     * a candidate attack's selection weight (SR _custom_weight_table; f2 =
+     * current weight in/out). NULL = parent's. Signature:
+     * float(*)(struct FTStruct*, int input_kind, float weight) - returns
+     * the (possibly overridden) weight. */
+    void                        *ai_attack_weight_routine;
+
+    /* SR Crash.asm:696-698: 1P-end BGM id. 0 = use parent's. */
+    int                          remix_1p_end_bgm;
+
+    /* SR Crash.asm:700-701: SinglePlayer.set_ending_image file_id. 0 =
+     * use parent's. */
+    int                          remix_1p_ending_image_file_id;
+
+    /* SR Crash.asm:681: default costumes table (per-fighter 8-byte
+     * indices into the costume tex array, indexed by player port).
+     * NULL = use parent's. */
+    const unsigned char         *default_costumes;
+    int                          default_costumes_count;
+
+    /* SR Costumes.asm num_costumes: number of selectable costumes for the CSS
+     * color cycle. Vanilla is capped at 4 (the 4 C-buttons map to royal[0..3]);
+     * synths can have more (Crash = 6). 0 = fall back to the vanilla 4-button
+     * mapping. The costume value is the in-match mat-anim frame index, so the
+     * model must carry this many costume frames. */
+    int                          costume_count;
+
+    /* SR Crash.asm:682: team costume index per team (3 entries: red,
+     * green, blue / red, blue, yellow per SR enum). 0xFF = unset. */
+    unsigned char                team_costume[4];
+
+    /* SR Crash.asm:705-712: charge-smash hold frame counts (3 entries:
+     * forward, up, down). NULL = use parent's. */
+    const unsigned char         *charge_smash_frames;
+
+    /* SR CustomGrabAction.asm + Wario.asm:624: when THIS fighter grabs an
+     * opponent, the grabbed opponent plays this action instead of the usual
+     * CapturePulled (0xAB). Wario = ThrownDK (0xB8: opponent on their back,
+     * struggling). 0 = no override (vanilla CapturePulled). Keyed by the
+     * GRABBING fighter's fkind. */
+    int                          custom_capture_action;
+
+    /* SR CustomGrabAction.asm capture_dk_break_fix_ + Wario.asm:629-634:
+     * companion to custom_capture_action when the action is ThrownDK. Routine
+     * deciding whether the grabbed opponent's mash/break-out is suppressed.
+     * NULL = vanilla break-out. Keyed by the GRABBING fighter's fkind. */
+    PortFTCaptureDkInterruptFn   custom_capture_dk_interrupt;
+
+    /* SR resultsscreen.asm add_to_results_screen: per-fighter VS-results data.
+     * A synth winner must use ITS OWN values here, never the parent's. The
+     * decomp results consumers (announce / winner name / "WINS!" x) index
+     * 12-entry vanilla tables that OOB on a synth fkind, so they read these
+     * for fkind >= nFTKindEnumCount. results_name == NULL means a synth never
+     * registered results data (a misconfiguration, not a Mario fallback). */
+    int                          results_announce_fgm;   /* winner announce voice FGM */
+    const char                  *results_name;           /* on-screen winner name string */
+    float                        results_name_lx;         /* name string left-x (SR str_lx) */
+    float                        results_name_scale;      /* name string x-scale (SR str_scale) */
+    float                        results_wins_lx;         /* "WINS!" string left-x (SR wins_lx) */
+
+    /* SR resultsscreen.asm winner_logo_fix_/_zoom_fix_/_color_fix_: the
+     * spinning series-emblem model rendered behind the winner. SR extends the
+     * three per-character tables that the vanilla mnVSResultsMakeEmblem reads
+     * to swap the DObjDesc / MObjSub / MatAnimJoint offsets into the grown
+     * FTEmblemModels file (reloc 0x23). These are byte offsets into that file;
+     * CE owns and reloads the grown file, and publishes its current base via
+     * port_set_results_emblem_base. results_emblem_valid == 0 means the synth
+     * registered no emblem, so the results screen draws no emblem (never the
+     * parent's). SR's "zoom"/"color" table labels are misleading; the actual
+     * swapped targets are MObjSub (zoom table) and MatAnimJoint (color table). */
+    int                          results_emblem_valid;    /* 1 if emblem offsets registered */
+    unsigned int                 results_emblem_dobjdesc; /* SR series_logo offset */
+    unsigned int                 results_emblem_mobjsub;  /* SR series_logo_zoom offset */
+    unsigned int                 results_emblem_matanim;  /* SR series_logo_color offset */
+} FighterDescriptor;
+
+/* Register or replace a fighter's row. Resizes if fkind exceeds current
+ * capacity. Caller-owned descriptor is shallow-copied. Registration is
+ * MOD_INIT only -- not thread-safe for concurrent reads. */
+void  port_fighter_register(int fkind, const FighterDescriptor *src);
+
+/* Returns NULL if fkind out of range / unregistered. Field-specific
+ * accessors below return safe defaults instead. */
+const FighterDescriptor *port_fighter_descriptor(int fkind);
+
+struct FTData              *port_fighter_data(int fkind);
+struct FTStatusDesc        *port_fighter_special_descs(int fkind);
+int                         port_fighter_special_descs_count(int fkind);
+PortFTSpecialEnterFn        port_fighter_special_handler(int fkind, int kind);
+int                         port_fighter_entry_appear(int fkind, int entry_id);
+void                        port_fighter_entry_make_effect(int fkind, struct FTStruct *fp);
+struct FTOpeningDesc       *port_fighter_opening_descs(int fkind);
+struct FTCostume           *port_fighter_costume_row(int fkind);
+float                       port_fighter_scale(int fkind);
+int                         port_fighter_skeleton_col_anim_base(int fkind);
+int                         port_fighter_down_bounce_fgm(int fkind);
+int                         port_fighter_public_call_fgm(int fkind);
+void                       *port_fighter_yoshi_egg_damage_coll(int fkind);
+void                       *port_fighter_computer_attack_list(int fkind);
+
+/* SR engine-extension accessors. */
+int                         port_fighter_shield_hitlag_skip(int fkind,
+                                                             struct GObj *fighter_gobj,
+                                                             int status_id);
+int                         port_fighter_ecb_override(struct FTStruct *fp,
+                                                       int next_status_id,
+                                                       float *out_upper,
+                                                       float *out_middle);
+int                         port_fighter_kirby_hat_id(int fkind);
+
+/* Per-player "pending custom hat id" carried from the inhale-eat path to the
+ * copy-apply paths. The decomp stores only the copy POWER fkind in
+ * status_vars.kirby.specialn.copy_id, then re-derives the hat at apply time as
+ * copy[copy_id].copy_modelpart_id. That re-derivation collides for a synth: a
+ * synth's power fkind is its parent (Crash -> Mario), so copy[Mario] yields
+ * Mario's vanilla hat (0x0C) instead of the synth's custom hat (0x2A). When
+ * Kirby eats a synth, the eat path records the synth's hat id here; the apply
+ * sites (ftKirbySpecialNCopyInitCopyVars, ftManagerMakeFighter) read it back
+ * and use the custom hat id when it is set (>= 0x0F). hat_id 0 clears it.
+ *
+ * Vanilla copies never set this (eat path only records for a KHE-resolved
+ * synth), so vanilla behavior is unchanged. Indexed by FTStruct.player.
+ *
+ * The slot itself lives in KirbyHatEngine; these forward through handlers the
+ * mod installs at MOD_INIT via port_kirby_register_pending_hat_handlers. Before
+ * the mod registers (or after it exits) set is a no-op and get returns 0. */
+typedef void (*PortKirbySetPendingHatFn)(int player, int hat_id);
+typedef int  (*PortKirbyGetPendingHatFn)(int player);
+void                        port_kirby_register_pending_hat_handlers(PortKirbySetPendingHatFn set,
+                                                                     PortKirbyGetPendingHatFn get);
+void                        port_kirby_set_pending_hat(int player, int hat_id);
+int                         port_kirby_get_pending_hat(int player);
+
+/* "Active copied-special fkind" override. When Kirby copies a SYNTH fighter
+ * (copy_id >= nFTKindEnumCount), SR runs the synth's own neutral-B routine on
+ * Kirby (e.g. CrashNSP.ground_initial_), which puts Kirby into the SYNTH's
+ * special action id (>= 0xDC). That action's status descriptor lives in the
+ * SYNTH's special_descs table, not Kirby's, so ftMainSetStatus must key its
+ * special-desc lookup off the synth fkind for the duration of that call. The
+ * copy-special dispatch (ftKirbySpecialN/AirNSetStatusSelect) sets this to the
+ * copy_id right before invoking the synth handler and clears it (0/Null) after.
+ * ftMainSetStatus consults it; when unset (default) the lookup uses fp->fkind
+ * so Kirby's own specials and vanilla copies are unaffected. */
+void                        port_kirby_set_copy_special_fkind(int fkind);
+int                         port_kirby_get_copy_special_fkind(void);
+
+int                         port_fighter_crowd_chant_fgm(int fkind);
+const char                 *port_fighter_action_string(int fkind, int action_id);
+void                       *port_fighter_ai_attack_prevent_routine(int fkind);
+void                       *port_fighter_ai_recovery_routine(int fkind);
+void                       *port_fighter_ai_attack_weight_routine(int fkind);
+int                         port_fighter_remix_1p_end_bgm(int fkind);
+int                         port_fighter_remix_1p_ending_image_file_id(int fkind);
+const unsigned char        *port_fighter_default_costumes(int fkind, int *out_count);
+int                         port_fighter_team_costume(int fkind, int team);
+const unsigned char        *port_fighter_charge_smash_frames(int fkind);
+int                         port_fighter_costume_count(int fkind);
+float                       port_fighter_css_spotlight_scale(int fkind);
+
+/* SR custom capture-action accessors. _action returns the grabbed-opponent
+ * action override for a grabber fkind (0 = none, use vanilla CapturePulled).
+ * _dk_interrupt runs the grabber's break-out-skip routine and returns nonzero
+ * to suppress the grabbed opponent's mash-out (0 if unregistered = vanilla). */
+int                         port_fighter_custom_capture_action(int fkind);
+int                         port_fighter_custom_capture_dk_interrupt(int fkind,
+                                                                     struct FTStruct *grabber_fp);
+
+/* VS-results accessors. For a synth fkind the decomp results consumers read
+ * these instead of indexing the 12-entry vanilla tables. _name returns NULL
+ * if the synth registered no results data (caller skips / surfaces the gap;
+ * it never falls back to the parent). */
+int                         port_fighter_results_announce_fgm(int fkind);
+const char                 *port_fighter_results_name(int fkind);
+float                       port_fighter_results_name_lx(int fkind);
+float                       port_fighter_results_name_scale(int fkind);
+float                       port_fighter_results_wins_lx(int fkind);
+
+/* VS-results spinning emblem (SR winner-logo). CE publishes the current base
+ * of the loaded FTEmblemModels blob via port_set_results_emblem_base after
+ * every scene reset (the blob's internal pointer tokens are generation-scoped,
+ * so the base must be refreshed each time). For a synth that registered emblem
+ * offsets, port_fighter_results_emblem resolves the three model pointers from
+ * (base + offset) and returns 1; it returns 0 (drawing nothing) if the synth
+ * registered no emblem or the base has not been published. */
+void                        port_set_results_emblem_base(void *base);
+int                         port_fighter_results_emblem(int fkind,
+                                                        void **out_dobjdesc,
+                                                        void **out_mobjsub,
+                                                        void **out_matanim);
+
+/* Walk every registered fkind in ascending order. Used by figatree-heap
+ * sizing and other "iterate every fighter" loops that previously walked
+ * the vanilla array length. */
+typedef void (*PortFighterForEachFn)(int fkind, const FighterDescriptor *desc, void *user);
+void  port_fighter_for_each(PortFighterForEachFn cb, void *user);
+
+/* Seeds slots [0, 27) from the vanilla decomp arrays. Called once at
+ * PortInit. Safe to call again -- existing synth rows past 27 are kept,
+ * vanilla rows are overwritten. */
+void  port_fighter_seed_vanilla(void);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* PORT_FIGHTER_REGISTRY_H */

--- a/port/hooks/Events.cpp
+++ b/port/hooks/Events.cpp
@@ -22,4 +22,10 @@ extern "C" void PortRegisterEvents(void) {
     REGISTER_EVENT(DisplayPostUpdateEvent);
     REGISTER_EVENT(EngineRenderMenubarEvent);
     REGISTER_EVENT(EngineRenderModsEvent);
+
+    REGISTER_EVENT(FighterEnvColorQueryEvent);
+    REGISTER_EVENT(FighterDamageDirectionApplyEvent);
+    REGISTER_EVENT(FighterHitboxSlotResetEvent);
+    REGISTER_EVENT(FighterParentKindResolveEvent);
+    REGISTER_EVENT(FighterRapidJabStatusQueryEvent);
 }

--- a/port/hooks/Events.h
+++ b/port/hooks/Events.h
@@ -11,3 +11,4 @@
 #pragma once
 
 #include "list/EngineEvent.h"
+#include "list/FighterEvent.h"

--- a/port/hooks/list/FighterEvent.h
+++ b/port/hooks/list/FighterEvent.h
@@ -1,0 +1,78 @@
+/*
+ * FighterEvent.h — Fighter-system query/notify events for BattleShip mods.
+ *
+ * These are mid-function override points inside decomp fighter code where
+ * no discrete engine symbol exists to detour (the surrounding functions are
+ * thousand-line procs or fkind-keyed macros). Each event carries a mutable
+ * payload: the engine fires it with vanilla defaults filled in, listeners
+ * (e.g. CharacterEngine) overwrite the out-field, and the engine reads the
+ * payload back after the CALL_EVENT. With zero listeners every event is a
+ * no-op and the engine takes the vanilla path — behavior is byte-identical
+ * without mods.
+ *
+ * Engine firing sites (all under #ifdef PORT in decomp/src):
+ *   - FighterEnvColorQueryEvent      — ftdisplaymain.c ftDisplayMainProcDisplay.
+ *                                      rgba in/out: 0 = no override, else the
+ *                                      RGBA word forced as the env color.
+ *   - FighterDamageDirectionApplyEvent — ftmain.c
+ *                                      ftMainProcessHitCollisionStatsMain, after
+ *                                      the engine computes default damage_lr.
+ *                                      Listener derives the hitbox id from the
+ *                                      attacker's attack_colls and overwrites
+ *                                      this_fp->damage_lr when its override slot
+ *                                      is set. Pointers are FTStruct* /
+ *                                      FTAttackColl* passed as void* so this
+ *                                      header stays decomp-type-free.
+ *   - FighterHitboxSlotResetEvent    — ftmain.c ftMainParseMotionEvent
+ *                                      make-attack path; notify-only. Listener
+ *                                      zeroes its per-player per-hitbox override
+ *                                      slot so stale state from a previous
+ *                                      attack with the same id doesn't bleed in.
+ *   - FighterParentKindResolveEvent  — ftcommonattack1/100.c fkind whitelists.
+ *                                      resolved_fkind in/out: initialized to
+ *                                      fkind; a listener that owns the
+ *                                      synth->parent map rewrites it so a synth
+ *                                      passes its parent's jab/rapid-jab gates.
+ *   - FighterRapidJabStatusQueryEvent — ftcommonattack100.c Start/Loop/End
+ *                                      SetStatus helpers. status_id in/out:
+ *                                      -1 = use the vanilla fkind switch; else
+ *                                      the per-character SR rapid-jab status id
+ *                                      for the given phase (0=begin, 1=loop,
+ *                                      2=end).
+ *
+ * Whole-function override points deliberately have NO event here — mods
+ * detour the engine symbol via mod_install_hook instead:
+ *   - ftMainSetStatus            (SR change_action_ per-status reset)
+ *   - ftParamClearAttackCollAll  (SR end_hitbox_ reset-all)
+ *   - ftSamusSpecialNGetChargeShotPosition (SR ball_position_fix_)
+ *
+ * Convention matches EngineEvent.h: REGISTER_EVENT in PortRegisterEvents
+ * (port/hooks/Events.cpp) allocates the EventID at engine init; CALL_EVENT
+ * fires it; mods subscribe with REGISTER_LISTENER.
+ */
+#pragma once
+
+#include "ship/events/EventTypes.h"
+#include "libultraship/bridge/eventsbridge.h"
+
+DEFINE_EVENT(FighterEnvColorQueryEvent,
+             int32_t player;
+             uint32_t rgba;);
+
+DEFINE_EVENT(FighterDamageDirectionApplyEvent,
+             void* this_fp;
+             void* attacker_fp;
+             void* attack_coll;);
+
+DEFINE_EVENT(FighterHitboxSlotResetEvent,
+             int32_t player;
+             int32_t slot;);
+
+DEFINE_EVENT(FighterParentKindResolveEvent,
+             int32_t fkind;
+             int32_t resolved_fkind;);
+
+DEFINE_EVENT(FighterRapidJabStatusQueryEvent,
+             int32_t fkind;
+             int32_t phase;
+             int32_t status_id;);

--- a/port/port.cpp
+++ b/port/port.cpp
@@ -47,6 +47,7 @@
 #endif
 #include "renderdoc_trigger.h"
 #include "port_log.h"
+#include "fighter_registry.h"
 
 #ifndef DISABLE_SCRIPTING
 #include <ship/scripting/ScriptLoader.h>
@@ -92,6 +93,20 @@ extern "C" struct MPGroundData *gMPCollisionGroundData_Ref(void) {
     return gMPCollisionGroundData;
 }
 extern "C" void* sModBridgeAnchorGroundDataRef = (void*)&gMPCollisionGroundData_Ref;
+
+/* Fighter data-files lookup table. Exposed so mod-loader code can
+ * write a registered character's FTData* into the trailing NULL-sentinel
+ * slot (index nFTKindEnumCount) during ftManagerMakeFighter and have
+ * the engine's internal `fp->data = dFTManagerDataFiles[fp->fkind]`
+ * indexing resolve to that entry. Same export-hole workaround as the
+ * other globals. */
+struct FTData;
+extern "C" struct FTData **dFTManagerDataFiles_Ref(void);
+extern "C" struct FTData **dFTManagerDataFiles_Ref(void) {
+    extern struct FTData *dFTManagerDataFiles[];
+    return dFTManagerDataFiles;
+}
+extern "C" void* sModBridgeAnchorDataFilesRef = (void*)&dFTManagerDataFiles_Ref;
 #endif
 
 #include <filesystem>
@@ -117,6 +132,10 @@ static void portCrtInvalidParameter(const wchar_t* expr, const wchar_t* func,
 	port_log_close();
 }
 
+static volatile LONG sMinidumpWritten = 0;
+static void portResolveSymbol(void* addr, char* out, size_t cap);
+static void portWriteMinidump(EXCEPTION_POINTERS* info, const char* prefix);
+
 static void portTerminateHandler()
 {
 	port_log("\n*** std::terminate called (uncaught C++ exception) ***\n");
@@ -135,11 +154,28 @@ static void portSignalHandler(int sig)
 		case SIGSEGV: name = "SIGSEGV"; break;
 		case SIGTERM: name = "SIGTERM"; break;
 	}
-	port_log("\n*** SIGNAL %s (%d) raised ***\n", name, sig);
+	port_log("\n*** SIGNAL %s (%d) raised - tid=%lu ***\n",
+	         name, sig, (unsigned long)GetCurrentThreadId());
+
+	/* signal() handlers get no EXCEPTION_POINTERS and abort() does not run the
+	 * SEH crash filter, so without this the abort path leaves no stack in the
+	 * log (and writes no dump). Capture + symbolize it here so a re-crash
+	 * self-reports the faulting frames. An uncaught C++ exception routes here
+	 * too (terminate -> abort -> SIGABRT), so the throw site is still on the
+	 * stack below. */
+	void* frames[48];
+	WORD nframes = RtlCaptureStackBackTrace(0, 48, frames, nullptr);
+	for (WORD i = 0; i < nframes; i++) {
+		char fsym[768] = {0};
+		portResolveSymbol(frames[i], fsym, sizeof(fsym));
+		port_log("    [%2u] %p %s\n", i, frames[i], fsym[0] ? fsym : "(no sym)");
+	}
+
+	if (InterlockedCompareExchange(&sMinidumpWritten, 1, 0) == 0) {
+		portWriteMinidump(nullptr, "signal");
+	}
 	port_log_close();
 }
-
-static volatile LONG sMinidumpWritten = 0;
 
 static void portResolveSymbol(void* addr, char* out, size_t cap)
 {
@@ -195,7 +231,7 @@ static void portWriteMinidump(EXCEPTION_POINTERS* info, const char* prefix)
 	MiniDumpWriteDump(GetCurrentProcess(), GetCurrentProcessId(), hf,
 	                  (MINIDUMP_TYPE)(MiniDumpWithDataSegs | MiniDumpWithThreadInfo |
 	                                  MiniDumpWithIndirectlyReferencedMemory),
-	                  &mei, nullptr, nullptr);
+	                  info ? &mei : nullptr, nullptr, nullptr);
 	CloseHandle(hf);
 	port_log("    %s minidump = %s\n", prefix, dumpPath);
 }
@@ -975,6 +1011,14 @@ static int PortInitImpl(int argc, char* argv[]) {
 		port_log("SSB64: HookManager::Init failed - mods will not load\n");
 	}
 #endif
+
+	/* Seed the per-fkind dispatch registry from the vanilla decomp arrays
+	 * BEFORE any mod runs. Mods can overwrite vanilla rows or add synth
+	 * rows past nFTKindEnumCount via port_fighter_register at MOD_INIT;
+	 * the engine reads through registry accessors instead of fixed-size
+	 * vanilla arrays, so synth fkinds never OOB those tables. */
+	port_fighter_seed_vanilla();
+	port_log("SSB64: fighter registry seeded\n");
 
 #ifndef DISABLE_SCRIPTING
 	/* Mount mods/ entries (folders, .o2r, .zip) into the LUS

--- a/port/port_log.c
+++ b/port/port_log.c
@@ -32,5 +32,8 @@ void port_log(const char *fmt, ...)
 	va_start(ap, fmt);
 	vfprintf(sLogFile, fmt, ap);
 	va_end(ap);
-	fflush(sLogFile);
+	/* fflush on every call costs seconds per frame on a slow drive when
+	 * figatree watchdogs fire 28x per frame during a stuck APPEAR. Rely on
+	 * stdio's buffer + OS-on-exit flush for normal logging; crash dumps
+	 * have their own flush path. */
 }

--- a/port/resource/RelocPointerTable.cpp
+++ b/port/resource/RelocPointerTable.cpp
@@ -159,17 +159,25 @@ void *portRelocResolvePointerDebug(uint32_t token, const char *file, int line)
     }
     uint32_t index = 0;
     if (!decodeToken(token, &index)) {
-        uint32_t tokenGen   = token >> TOKEN_GENERATION_SHIFT;
-        uint32_t tokenIndex = token & TOKEN_INDEX_MASK;
-        uint32_t slotGen    = (sSlots && tokenIndex < sNextIndex) ? sSlots[tokenIndex].gen : 0;
-        if (file != nullptr) {
-            spdlog::error("RelocPointerTable: invalid/stale token 0x{:08X} "
-                          "(token_gen=0x{:03X} slot_gen=0x{:03X} index={} max={}, caller={}:{})",
-                          token, tokenGen, slotGen, tokenIndex, sNextIndex - 1, file, line);
-        } else {
-            spdlog::error("RelocPointerTable: invalid/stale token 0x{:08X} "
-                          "(token_gen=0x{:03X} slot_gen=0x{:03X} index={} max={})",
-                          token, tokenGen, slotGen, tokenIndex, sNextIndex - 1);
+        /* Rate-limit: an APPEAR figatree binding pass can resolve the same
+         * stale token thousands of times per frame (each joint stream re-
+         * checks). spdlog flushes on error so unrate-limited logging stalls
+         * the main thread. Cap to one log per 1024 misses; the message is
+         * the same value anyway. */
+        static uint32_t sStaleLogCount = 0;
+        if ((sStaleLogCount++ & 0x3FF) == 0) {
+            uint32_t tokenGen   = token >> TOKEN_GENERATION_SHIFT;
+            uint32_t tokenIndex = token & TOKEN_INDEX_MASK;
+            uint32_t slotGen    = (sSlots && tokenIndex < sNextIndex) ? sSlots[tokenIndex].gen : 0;
+            if (file != nullptr) {
+                spdlog::error("RelocPointerTable: invalid/stale token 0x{:08X} "
+                              "(token_gen=0x{:03X} slot_gen=0x{:03X} index={} max={}, caller={}:{}, miss_count={})",
+                              token, tokenGen, slotGen, tokenIndex, sNextIndex - 1, file, line, sStaleLogCount);
+            } else {
+                spdlog::error("RelocPointerTable: invalid/stale token 0x{:08X} "
+                              "(token_gen=0x{:03X} slot_gen=0x{:03X} index={} max={}, miss_count={})",
+                              token, tokenGen, slotGen, tokenIndex, sNextIndex - 1, sStaleLogCount);
+            }
         }
         return nullptr;
     }


### PR DESCRIPTION
Adds the hook plumbing for extending fighter behavior at runtime.

What's in here:

- A per-fighter dispatch registry that the engine reads through instead of indexing the fixed-size vanilla fighter-kind arrays directly. It's seeded from the vanilla decomp tables at startup, before anything else runs, so default behavior is unchanged. Rows can be overwritten or appended past the vanilla count, and every read goes through an accessor, so an out-of-range kind never runs off the end of the original tables.

- A FighterEvent type in the port event system. The decomp fighter code fires these events directly, so port code can observe fighter state changes without patching the decomp by hand.

- PORT hooks across the decomp fighter code that raise those events at the relevant points.

- Reloc bridge and pointer-table updates that back the registry, plus the libultraship include paths the game target needs now that the decomp hooks pull in the event headers.

The decomp side lives in a companion branch and the submodule pointer is bumped to pick it up. Built on top of current main; default play is unaffected when nothing registers.
