### PR TITLE
ci: add per-PR cross-platform build gate

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,117 @@
+name: Build
+
+# Per-PR compile gate. Builds the BattleShip binary on Windows, Linux, and
+# macOS on every pull_request and push to main, so a contribution that fails to
+# compile on a platform is caught before review and merge — the exact gap a
+# Windows-only change (e.g. a MinHook-based mod loader) would otherwise slip
+# through until a maintainer builds it by hand on three machines.
+#
+# Build-only by design: never packages an installer, never produces
+# BattleShip.o2r. Like release.yml it is ROM-independent end-to-end. Dep lists
+# and build invocations mirror release.yml's desktop jobs minus packaging, so a
+# green run here predicts a green release build.
+#
+# Codegen (credits text, CSS scroll-arrow PNGs, reloc tables, embedded icon) is
+# driven entirely by CMake custom targets/commands — no manual presteps here;
+# we only ensure their tools (Python3 + Pillow) are present, then configure +
+# build and let CMake run them as build dependencies.
+
+on:
+  pull_request:
+  push:
+    branches: [main]
+  workflow_dispatch:    # manual trigger for smoke-testing
+
+permissions:
+  contents: read
+
+# A fresh push to a PR branch cancels the previous, still-running build for the
+# same ref — no point spending runner minutes finishing a stale commit.
+concurrency:
+  group: build-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  linux:
+    name: Linux (clang)
+    runs-on: ubuntu-22.04
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          submodules: recursive
+          # The updater derives the version via `git describe --tags` at
+          # configure time; a shallow clone omits tags and breaks configure.
+          fetch-depth: 0
+      - name: Install build deps
+        # libultraship find_package set (libzip, nlohmann_json, tinyxml2,
+        # spdlog, SDL2, GLEW). python3-pil: tools/generate_arrow_svg.py +
+        # tools/png_to_c_array.py import PIL; the CSS-arrow rules in
+        # CMakeLists.txt are unconditional and fire every build.
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y \
+            cmake ninja-build zip clang \
+            libsdl2-dev libzip-dev libglew-dev \
+            nlohmann-json3-dev libtinyxml2-dev libspdlog-dev \
+            libgl1-mesa-dev libegl1-mesa-dev \
+            libxrandr-dev libxinerama-dev libxcursor-dev libxi-dev \
+            python3 python3-pil imagemagick file
+          # libzip-dev exports zipcmp / zipmerge / ziptool as IMPORTED
+          # executables the distro doesn't package; CMake's existence check
+          # fires at find_package() even though we never run them. Stub them.
+          sudo touch /usr/bin/zipcmp /usr/bin/zipmerge /usr/bin/ziptool
+          sudo chmod +x /usr/bin/zipcmp /usr/bin/zipmerge /usr/bin/ziptool
+      - name: Use clang as the C/C++ compiler
+        # GCC trips on decomp-style shadow headers Clang accepts; match the
+        # macOS-validated toolchain.
+        run: |
+          echo "CC=clang"    >> "$GITHUB_ENV"
+          echo "CXX=clang++" >> "$GITHUB_ENV"
+      - name: Configure
+        run: cmake -B build -DCMAKE_BUILD_TYPE=Release -DNON_PORTABLE=ON
+      - name: Build
+        run: cmake --build build -j"$(nproc)"
+
+  macos:
+    name: macOS (arm64)
+    runs-on: macos-14
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          submodules: recursive
+          fetch-depth: 0
+      - name: Install build deps
+        run: |
+          brew install cmake ninja sdl2 glew libzip nlohmann-json tinyxml2 spdlog
+          python3 -m pip install --break-system-packages Pillow
+      - name: Configure
+        run: cmake -B build -DCMAKE_BUILD_TYPE=Release -DNON_PORTABLE=ON
+      - name: Build
+        run: cmake --build build -j"$(sysctl -n hw.ncpu)"
+
+  windows:
+    name: Windows (MSVC)
+    runs-on: windows-2022
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          submodules: recursive
+          fetch-depth: 0
+      - name: Install build deps
+        # SDL2 comes from vcpkg, bootstrapped by libultraship's CMake. Pillow
+        # for the unconditional CSS-arrow codegen.
+        run: |
+          choco install ninja -y
+          python -m pip install --upgrade pip
+          python -m pip install Pillow
+        shell: pwsh
+      - name: Configure
+        # Default Visual Studio multi-config generator (build with
+        # --config Release; no vcvars needed). Pin Python3_EXECUTABLE to the
+        # same `python` pip installed Pillow under — GHA Windows images ship
+        # multiple interpreters and CMake's FindPython can otherwise pick one
+        # without Pillow, failing the CSS-arrow rules mid-build.
+        run: cmake -B build -DCMAKE_BUILD_TYPE=Release "-DPython3_EXECUTABLE=$((Get-Command python).Source)"
+        shell: pwsh
+      - name: Build
+        run: cmake --build build --config Release -j 4


### PR DESCRIPTION
## What

Adds `.github/workflows/build.yml` — a build-only CI workflow that compiles the `ssb64` target on **Windows (MSVC)**, **Linux (clang)**, and **macOS (arm64)** for every `pull_request` and push to `main`.

## Why

Today the only workflow is `release.yml`, which runs solely on `v*` tags. No check verifies that a contribution even *compiles* across platforms before review or merge — a maintainer has to build it by hand on three machines to find out. That's a real gap with active cross-platform work in flight (e.g. a mod loader using a Windows-only detour primitive would pass review and silently break the macOS arm64 release target).

This gate catches that automatically, in red, on the PR.

## Design

- **Build-only.** Never packages an installer, never produces `BattleShip.o2r`. Like `release.yml`, it's ROM-independent end-to-end, so it's safe for public CI.
- **Mirrors `release.yml`'s desktop jobs minus packaging**, so a green run here predicts a green release build:
  - Same `find_package` deps (libzip, nlohmann_json, tinyxml2, spdlog, SDL2, GLEW) + **Pillow** for the unconditional CSS scroll-arrow codegen.
  - `fetch-depth: 0` so the updater's `git describe --tags` resolves at configure time.
  - On Windows, `Python3_EXECUTABLE` is pinned to the same `python` that pip installed Pillow under, avoiding the multi-interpreter "Pillow is required" failure.
- **No manual codegen presteps.** Credits text, CSS arrows, reloc tables, and the embedded icon are all driven by CMake custom targets/commands as build dependencies — the workflow only ensures their tools (Python3 + Pillow) are present.
- `concurrency` cancels superseded runs on the same ref to save runner minutes.

## Notes for review

- Builds the `us` version only (default). The `us`/`jp` matrix in `release.yml` is release-scoped; a single region is enough to catch compile breakage.
- macOS runner minutes carry a higher multiplier — flagging it in case you'd prefer the macOS job gated to non-draft PRs or `main` only. Easy to adjust.