### PR TITLE
docs: add a modding guide with the full event catalog

### DIFF
--- a/README.md
+++ b/README.md
@@ -228,6 +228,7 @@ scripts/      packaging (.dmg / .AppImage / .zip), worktree helper
 
 ### Further reading
 
+- [`docs/modding.md`](docs/modding.md) — writing native C mods: the event catalog, function detours, and fighter override points
 - [`docs/architecture.md`](docs/architecture.md) — project status, ROM info, dependency map, source-tree layout
 - [`docs/c_conventions.md`](docs/c_conventions.md) — decomp naming prefixes, IDO idioms to preserve, code style, macros
 - [`docs/n64_reference.md`](docs/n64_reference.md) — RDRAM, RSP/RDP, GBI, audio, threading, endianness primer

--- a/docs/modding.md
+++ b/docs/modding.md
@@ -1,0 +1,232 @@
+# Modding BattleShip
+
+BattleShip ships a native **C mod** system: at boot the engine compiles each
+mod's `.c` source at runtime (via libtcc), links it against the engine's own
+export table, and calls the mod's `ModInit`. Mods can subscribe to engine
+events, detour any exported engine function, and play custom audio — without
+recompiling the port.
+
+This page is the **map**. It tells you what the system can do, the three ways a
+mod hooks into the engine, and a complete reference of the events you can
+subscribe to. For the step-by-step authoring workflow (project layout, build,
+packaging to `.o2r`, hot reload), the canonical how-to is
+[`workspace/template/README.md`](../workspace/template/README.md).
+
+> **Scope:** the mod loader is **desktop-only** (Windows / Linux / macOS). It is
+> compiled out on Android and any build configured with `-DDISABLE_SCRIPTING`.
+> Mods are loaded from `<install>/mods/`, either as unpacked folders (handy for
+> development) or `.o2r` archives (for distribution).
+
+---
+
+## Start here
+
+1. Read [`workspace/template/README.md`](../workspace/template/README.md) — the
+   authoring guide: folder layout, `manifest.json`, building, packaging, hot
+   reload.
+2. Copy `workspace/template/` to start a new mod. It builds a heartbeat mod that
+   logs once per second — the smallest complete example.
+3. See `workspace/hooktest/` for a minimal **function-detour** mod (it hooks
+   `osSpTaskStartGo` and passes through).
+4. Use this page as your reference for **which events exist** and **how to read
+   their payloads**.
+
+---
+
+## Three ways to extend the engine
+
+Pick the mechanism that matches what you're trying to do.
+
+### 1. Event listeners — react to engine moments
+
+The engine fires named events at well-defined points (per-frame, per-display,
+ImGui render). Subscribe from `ModInit`, unsubscribe from `ModExit`:
+
+```c
+#include "mod.h"
+#include "port/hooks/Events.h"
+
+ListenerID gListener;
+
+void OnFrame(IEvent* event) {
+    /* runs every frame, after the game tick */
+}
+
+MOD_INIT() {
+    gListener = REGISTER_LISTENER(GamePostUpdateEvent, EVENT_PRIORITY_NORMAL, OnFrame);
+}
+
+MOD_EXIT() {
+    UNREGISTER_LISTENER(GamePostUpdateEvent, gListener);
+}
+```
+
+This is the right tool when an engine event already exists for the moment you
+care about. See the [Event reference](#event-reference) below.
+
+### 2. Function detours — replace engine behavior
+
+Any function in the engine's export table can be detoured. Calls to it land in
+your replacement; the original comes back through an out-pointer so you can call
+it (chain) or skip it:
+
+```c
+typedef sb32 (*orig_fn)(GObj*);
+static orig_fn s_orig = NULL;
+
+static sb32 my_replacement(GObj* g) {
+    /* before */
+    sb32 rv = s_orig(g);   /* call the original (optional) */
+    /* after */
+    return rv;
+}
+
+MOD_INIT() {
+    mod_install_hook("itTomatoFallProcUpdate", my_replacement, (void**)&s_orig);
+}
+```
+
+Hooks are **owned by the installing mod** — on unload/hot-reload the engine
+removes each of the mod's hooks before re-running `ModInit`, so reloading a
+hook-installing mod is safe. Use this when there's a discrete engine symbol for
+the behavior you want to change.
+
+### 3. Fighter query/override events — patch mid-function decisions
+
+Some fighter decisions happen deep inside thousand-line procs or `fkind`-keyed
+macros where there's no discrete symbol to detour. For those, the engine fires a
+**Fighter event** carrying a mutable payload: it fills in the vanilla default,
+your listener can overwrite the out-field, and the engine reads the payload back.
+With zero listeners these are no-ops and the game behaves byte-identically.
+
+```c
+void OnEnvColorQuery(IEvent* event) {
+    FighterEnvColorQueryEvent* e = (FighterEnvColorQueryEvent*)event;
+    if (e->player == 0) {
+        e->rgba = 0xFF0000FF;   /* force player 1's env color to red */
+    }
+}
+
+MOD_INIT() {
+    REGISTER_LISTENER(FighterEnvColorQueryEvent, EVENT_PRIORITY_NORMAL, OnEnvColorQuery);
+}
+```
+
+See the [Fighter events](#fighter-events) table for each override point's
+payload and semantics.
+
+---
+
+## Event reference
+
+Every event is declared with `DEFINE_EVENT`, which generates a struct of the
+same name whose first member is `IEvent Event;` followed by the payload fields.
+In a listener, cast the `IEvent*` you receive to the event's type and
+read/write its fields:
+
+```c
+void OnX(IEvent* event) {
+    SomeEvent* e = (SomeEvent*)event;
+    /* read e->field, write e->out_field, or cancel with event->Cancelled = true */
+}
+```
+
+Listener priority is one of `EVENT_PRIORITY_LOW`, `EVENT_PRIORITY_NORMAL`,
+`EVENT_PRIORITY_HIGH` (higher runs first).
+
+### Engine & UI events
+
+Declared in [`port/hooks/list/EngineEvent.h`](../port/hooks/list/EngineEvent.h).
+These carry **no payload** — they're pure notifications.
+
+| Event | Fires |
+|-------|-------|
+| `GamePreUpdateEvent` | In `port.cpp`, **before** the per-frame game tick (`gmMain` dispatch). |
+| `GamePostUpdateEvent` | In `port.cpp`, **after** the per-frame game tick. The most common hook for reading/writing game state each frame. |
+| `DisplayPreUpdateEvent` | Before the GFX dispatch (RCP frame submit). |
+| `DisplayPostUpdateEvent` | After the GFX dispatch. |
+| `EngineRenderMenubarEvent` | During ImGui menubar render — add your own menu items here. |
+| `EngineRenderModsEvent` | During ImGui main render — draw your own ImGui windows here. |
+
+### Fighter events
+
+Declared in [`port/hooks/list/FighterEvent.h`](../port/hooks/list/FighterEvent.h).
+These are **mutable** — fill in the out-field to override, leave it to take the
+vanilla path. Pointer fields are passed as `void*` to keep the header free of
+decomp types; cast them to the documented decomp type inside your listener.
+
+| Event | Fires at | Payload | Semantics |
+|-------|----------|---------|-----------|
+| `FighterEnvColorQueryEvent` | `ftdisplaymain.c` `ftDisplayMainProcDisplay` | `int32_t player; uint32_t rgba;` | **Query.** `rgba` in/out: `0` = no override; any other value is forced as the env color (RGBA word). |
+| `FighterDamageDirectionApplyEvent` | `ftmain.c` `ftMainProcessHitCollisionStatsMain`, after default `damage_lr` is computed | `void* this_fp; void* attacker_fp; void* attack_coll;` | **Apply.** Derive the hitbox id from the attacker's `attack_colls`; overwrite `this_fp->damage_lr` (cast `this_fp` to `FTStruct*`, `attack_coll` to `FTAttackColl*`). |
+| `FighterHitboxSlotResetEvent` | `ftmain.c` `ftMainParseMotionEvent` make-attack path | `int32_t player; int32_t slot;` | **Notify.** Zero your per-player/per-hitbox override slot so stale state from a prior attack with the same id doesn't bleed in. |
+| `FighterParentKindResolveEvent` | `ftcommonattack1/100.c` `fkind` whitelists | `int32_t fkind; int32_t resolved_fkind;` | **Query.** `resolved_fkind` in/out: starts at `fkind`; rewrite it so a synthetic fighter passes its parent's jab / rapid-jab gates. |
+| `FighterRapidJabStatusQueryEvent` | `ftcommonattack100.c` Start/Loop/End `SetStatus` helpers | `int32_t fkind; int32_t phase; int32_t status_id;` | **Query.** `status_id` in/out: `-1` = use the vanilla `fkind` switch; else the rapid-jab status id for `phase` (`0`=begin, `1`=loop, `2`=end). |
+
+> **Whole-function override points** deliberately have **no** event — detour the
+> engine symbol with `mod_install_hook` instead: `ftMainSetStatus`,
+> `ftParamClearAttackCollAll`, `ftSamusSpecialNGetChargeShotPosition`.
+
+---
+
+## A complete example: tint a fighter red
+
+A full mod that forces player 1's environment color to red. Drop this in
+`src/` of a copied template, build, and load.
+
+```c
+/* tint.c — force player 1's fighter env color to red. */
+#include "mod.h"
+#include "port/hooks/Events.h"
+
+static ListenerID s_listener;
+
+static void OnEnvColorQuery(IEvent* event) {
+    FighterEnvColorQueryEvent* e = (FighterEnvColorQueryEvent*)event;
+    if (e->player == 0) {       /* player index is 0-based */
+        e->rgba = 0xFF0000FF;   /* R=FF G=00 B=00 A=FF */
+    }
+}
+
+MOD_INIT() {
+    s_listener = REGISTER_LISTENER(FighterEnvColorQueryEvent,
+                                   EVENT_PRIORITY_NORMAL, OnEnvColorQuery);
+    mod_log("[Tint] init OK\n");
+}
+
+MOD_EXIT() {
+    UNREGISTER_LISTENER(FighterEnvColorQueryEvent, s_listener);
+}
+```
+
+---
+
+## Gotchas
+
+- **`PORT` struct layout.** The engine is built with `-DPORT`, which changes the
+  layout of many decomp structs (pointer fields collapse to `u32` reloc tokens).
+  `mod.h` defines `PORT 1` before anything else for you — keep that include
+  first, or cross-boundary struct reads return garbage.
+- **Logging.** `mod_log(fmt, ...)` writes to `%APPDATA%/BattleShip/ssb64.log`
+  (unbuffered) and works in both Debug and Release. `printf`/`stderr` only
+  surface in the Debug-build console on Windows; in Release they go nowhere.
+  Rely on `mod_log`.
+- **Hot reload.** The Mods menu's Reload action runs every mod's `ModExit`,
+  removes its owned hooks, frees its compiled image, recompiles from disk, and
+  re-runs `ModInit`. Unregister listeners and free allocations in `ModExit` so
+  reload stays clean.
+- **Build errors surface at load, not at author-build time.** `merge_mod.py`
+  only preprocesses/amalgamates your sources; the real compile happens in libtcc
+  when the engine loads the mod. Watch `ssb64.log` for compile errors.
+
+---
+
+## Where the API is defined
+
+| Piece | File |
+|-------|------|
+| Author API (`MOD_INIT`, `mod_install_hook`, `mod_log`, `CALL_FUNC`) | `workspace/template/include/mod.h` |
+| Event macros (`DEFINE_EVENT`, `REGISTER_LISTENER`, `IEvent`, priorities) | libultraship `ship/events/EventTypes.h`, `bridge/eventsbridge.h` |
+| Event catalog | `port/hooks/list/EngineEvent.h`, `port/hooks/list/FighterEvent.h` |
+| Runtime loader / mod mount | `port/port.cpp` (`MountModsDir`), `port/mods/` |
+| Packaging helper | `cmake/ModO2R.cmake`, `tools/merge_mod.py` |

--- a/docs/modding.md
+++ b/docs/modding.md
@@ -28,7 +28,9 @@ packaging to `.o2r`, hot reload), the canonical how-to is
    logs once per second — the smallest complete example.
 3. See `workspace/hooktest/` for a minimal **function-detour** mod (it hooks
    `osSpTaskStartGo` and passes through).
-4. Use this page as your reference for **which events exist** and **how to read
+4. See `workspace/playertint/` for a minimal **fighter-event** mod (it tints
+   each player a distinct color via `FighterEnvColorQueryEvent`).
+5. Use this page as your reference for **which events exist** and **how to read
    their payloads**.
 
 ---
@@ -172,7 +174,10 @@ decomp types; cast them to the documented decomp type inside your listener.
 ## A complete example: tint a fighter red
 
 A full mod that forces player 1's environment color to red. Drop this in
-`src/` of a copied template, build, and load.
+`src/` of a copied template, build, and load. A complete, packaged version
+that tints **all four** players a distinct color ships in
+[`workspace/playertint/`](../workspace/playertint/) — copy that folder to start
+from a working fighter-event mod instead of the heartbeat template.
 
 ```c
 /* tint.c — force player 1's fighter env color to red. */
@@ -218,6 +223,11 @@ MOD_EXIT() {
 - **Build errors surface at load, not at author-build time.** `merge_mod.py`
   only preprocesses/amalgamates your sources; the real compile happens in libtcc
   when the engine loads the mod. Watch `ssb64.log` for compile errors.
+- **Pillow is a packaging dependency.** `merge_mod.py` imports Pillow (PIL). If
+  `cmake --build` fails with `No module named 'PIL'`, install it with
+  `pip install Pillow` — into the interpreter **CMake selected**, which can
+  differ from the `python` on your `PATH` (CMake's `find_package(Python3)` may
+  pick another install). The build output prints the interpreter path it found.
 
 ---
 

--- a/workspace/playertint/.gitignore
+++ b/workspace/playertint/.gitignore
@@ -1,0 +1,2 @@
+build/
+output/

--- a/workspace/playertint/CMakeLists.txt
+++ b/workspace/playertint/CMakeLists.txt
@@ -1,0 +1,154 @@
+# BattleShip "Player Tint" example mod — packaging-only build.
+#
+# Identical in shape to workspace/template/CMakeLists.txt: it does NOT
+# compile the mod (libtcc does that at runtime inside the engine). It only
+# amalgamates src/*.c via tools/merge_mod.py, copies headers/assets/manifest
+# into output/, and writes output/build.gen. After `cmake --build build`,
+# drop the output/ folder into <install>/mods/ (or pack it as .o2r).
+
+cmake_minimum_required(VERSION 3.10)
+project(BattleShipModPlayerTint)
+
+find_package(Python3 REQUIRED COMPONENTS Interpreter)
+
+set(PARENT_DIR ${CMAKE_CURRENT_SOURCE_DIR}/../..)
+set(LOCAL_INCLUDE_DIRS ${CMAKE_CURRENT_SOURCE_DIR}/include)
+
+set(INCLUDE_DIRS
+    ${LOCAL_INCLUDE_DIRS}
+    ${CMAKE_CURRENT_SOURCE_DIR}/src
+    ${PARENT_DIR}
+    ${PARENT_DIR}/port
+    ${PARENT_DIR}/decomp/src
+    ${PARENT_DIR}/decomp/include
+    ${PARENT_DIR}/libultraship/src
+    ${PARENT_DIR}/libultraship/include
+)
+
+file(GLOB_RECURSE SRC_FILES CONFIGURE_DEPENDS "${CMAKE_CURRENT_SOURCE_DIR}/src/*.c")
+list(FILTER SRC_FILES EXCLUDE REGEX ".*\\.inc\\.c")
+
+set(BUILD_GEN ${CMAKE_CURRENT_SOURCE_DIR}/output/build.gen)
+get_filename_component(OUTPUT_DIR ${BUILD_GEN} DIRECTORY)
+file(MAKE_DIRECTORY ${OUTPUT_DIR})
+
+set(INTERMEDIATE_OUTPUTS "")
+set(COPY_OUTPUTS "")
+set(DIST_OUTPUT ${CMAKE_CURRENT_SOURCE_DIR}/output/dist)
+
+# Generate preprocessed source file (leaves sources in output/dist)
+foreach(SOURCE_FILE ${SRC_FILES})
+    file(RELATIVE_PATH RELATIVE_FILE ${CMAKE_CURRENT_SOURCE_DIR}/src ${SOURCE_FILE})
+    set(OUTPUT_FILE ${DIST_OUTPUT}/${RELATIVE_FILE})
+    get_filename_component(INTERMEDIATE_DIR ${OUTPUT_FILE} DIRECTORY)
+
+    add_custom_command(
+        OUTPUT ${OUTPUT_FILE}
+        COMMAND ${CMAKE_COMMAND} -E make_directory ${INTERMEDIATE_DIR}
+        COMMAND Python3::Interpreter ${PARENT_DIR}/tools/merge_mod.py
+                --out ${OUTPUT_FILE}
+                --includes ${INCLUDE_DIRS}
+                --srcs ${SOURCE_FILE}
+        DEPENDS ${SOURCE_FILE} ${PARENT_DIR}/tools/merge_mod.py
+        VERBATIM
+    )
+
+    list(APPEND INTERMEDIATE_OUTPUTS ${OUTPUT_FILE})
+endforeach()
+
+# Copy headers into output folder
+foreach(INCLUDE_DIR ${LOCAL_INCLUDE_DIRS})
+    file(GLOB_RECURSE HEADER_FILES CONFIGURE_DEPENDS "${INCLUDE_DIR}/*.h")
+    foreach(HEADER_FILE ${HEADER_FILES})
+        file(RELATIVE_PATH RELATIVE_HEADER ${INCLUDE_DIR} ${HEADER_FILE})
+
+        set(OUTPUT_HEADER ${OUTPUT_DIR}/include/${RELATIVE_HEADER})
+
+        get_filename_component(HEADER_OUTPUT_DIR ${OUTPUT_HEADER} DIRECTORY)
+
+        add_custom_command(
+            OUTPUT ${OUTPUT_HEADER}
+            COMMAND ${CMAKE_COMMAND} -E make_directory ${HEADER_OUTPUT_DIR}
+            COMMAND ${CMAKE_COMMAND} -E copy_if_different ${HEADER_FILE} ${OUTPUT_HEADER}
+            DEPENDS ${HEADER_FILE}
+            VERBATIM
+        )
+
+        list(APPEND COPY_OUTPUTS ${OUTPUT_HEADER})
+    endforeach()
+endforeach()
+
+# Copy assets into output folder
+file(GLOB_RECURSE ASSET_FILES CONFIGURE_DEPENDS "${CMAKE_CURRENT_SOURCE_DIR}/assets/*")
+foreach(ASSET_FILE ${ASSET_FILES})
+    file(RELATIVE_PATH RELATIVE_ASSET ${CMAKE_CURRENT_SOURCE_DIR}/assets ${ASSET_FILE})
+
+    set(OUTPUT_ASSET ${OUTPUT_DIR}/${RELATIVE_ASSET})
+
+    get_filename_component(ASSET_OUTPUT_DIR ${OUTPUT_ASSET} DIRECTORY)
+
+    add_custom_command(
+        OUTPUT ${OUTPUT_ASSET}
+        COMMAND ${CMAKE_COMMAND} -E make_directory ${ASSET_OUTPUT_DIR}
+        COMMAND ${CMAKE_COMMAND} -E copy_if_different ${ASSET_FILE} ${OUTPUT_ASSET}
+        DEPENDS ${ASSET_FILE}
+        VERBATIM
+    )
+
+    list(APPEND COPY_OUTPUTS ${OUTPUT_ASSET})
+endforeach()
+
+# Copy manifest into output folder
+set(MANIFEST_FILE ${CMAKE_CURRENT_SOURCE_DIR}/manifest.json)
+set(OUTPUT_MANIFEST ${OUTPUT_DIR}/manifest.json)
+
+add_custom_command(
+    OUTPUT ${OUTPUT_MANIFEST}
+    COMMAND ${CMAKE_COMMAND} -E copy_if_different ${MANIFEST_FILE} ${OUTPUT_MANIFEST}
+    DEPENDS ${MANIFEST_FILE}
+    VERBATIM
+)
+list(APPEND COPY_OUTPUTS ${OUTPUT_MANIFEST})
+
+# Copy preview image if present (.png / .jpg / .jpeg). The runtime
+# loader picks the first match in that order for the Mods menu UI.
+foreach(PREVIEW_NAME preview.png preview.jpg preview.jpeg)
+    set(PREVIEW_SRC ${CMAKE_CURRENT_SOURCE_DIR}/${PREVIEW_NAME})
+    if(EXISTS ${PREVIEW_SRC})
+        set(PREVIEW_DST ${OUTPUT_DIR}/${PREVIEW_NAME})
+        add_custom_command(
+            OUTPUT ${PREVIEW_DST}
+            COMMAND ${CMAKE_COMMAND} -E copy_if_different ${PREVIEW_SRC} ${PREVIEW_DST}
+            DEPENDS ${PREVIEW_SRC}
+            VERBATIM
+        )
+        list(APPEND COPY_OUTPUTS ${PREVIEW_DST})
+    endif()
+endforeach()
+
+string(REPLACE ";" "\n" FORMATTED_FILE_LIST "${INTERMEDIATE_OUTPUTS}")
+string(REPLACE "${CMAKE_CURRENT_SOURCE_DIR}/output/" "" FORMATTED_FILE_LIST "${FORMATTED_FILE_LIST}")
+
+# Write build.gen as a build-time artifact via add_custom_command, not
+# file(WRITE) at configure time. file(WRITE) only fires on cmake
+# (re)configure, so deleting output/ and running `cmake --build` alone
+# leaves build.gen missing and the engine fails to find an entry point.
+add_custom_command(
+    OUTPUT ${BUILD_GEN}
+    COMMAND ${CMAKE_COMMAND} -E make_directory ${OUTPUT_DIR}
+    COMMAND ${CMAKE_COMMAND} -E echo "${FORMATTED_FILE_LIST}" > ${BUILD_GEN}
+    COMMENT "Writing build.gen entry-point manifest"
+    VERBATIM
+)
+list(APPEND COPY_OUTPUTS ${BUILD_GEN})
+
+add_custom_target(generate_packaged_mod ALL DEPENDS ${INTERMEDIATE_OUTPUTS} ${COPY_OUTPUTS})
+
+# When this mod is built inside the engine tree, the engine's
+# cmake/ModO2R.cmake module defines ssb64_add_mod_o2r_target. Hook it up
+# so `cmake --build build --target mod_playertint_o2r` produces an .o2r
+# next to output/. Outside the engine build the function is undefined and
+# this is a no-op; pack manually with torch (`torch pack output playertint.o2r o2r`).
+if(COMMAND ssb64_add_mod_o2r_target)
+    ssb64_add_mod_o2r_target(playertint)
+endif()

--- a/workspace/playertint/README.md
+++ b/workspace/playertint/README.md
@@ -1,0 +1,57 @@
+# Player Tint — Fighter event example mod
+
+A small, complete BattleShip mod that gives each player a distinct fighter
+color: **P1 red, P2 blue, P3 green, P4 yellow**. Useful for telling players
+apart, and a worked example of the **Fighter query/override event** system
+documented in [`docs/modding.md`](../../docs/modding.md).
+
+Where the template (`workspace/template`) shows a per-frame engine listener
+and `workspace/hooktest` shows a function detour, this mod shows the third
+extension mechanism: a **Fighter event**. It subscribes to
+`FighterEnvColorQueryEvent`, which the engine fires once per fighter per frame
+with `rgba` pre-filled to `0` ("take the vanilla color"). The listener writes a
+non-zero RGBA word to force a color instead:
+
+```c
+static void OnEnvColorQuery(IEvent* event) {
+    FighterEnvColorQueryEvent* e = (FighterEnvColorQueryEvent*)event;
+    if (e->player >= 0 && e->player < 4) {
+        e->rgba = kPlayerColors[e->player];   /* 0xRRGGBBAA */
+    }
+}
+```
+
+`FighterEnvColorQueryEvent`'s payload is all primitives (`int32 player`,
+`uint32 rgba`), so unlike the other Fighter events it needs **no** decomp-struct
+casts — which makes it the cleanest one to start from. With the mod unloaded the
+event has zero listeners and the engine takes the vanilla path, so fighters look
+exactly as they always did.
+
+## Build
+
+```bash
+cmake -B build
+cmake --build build
+```
+
+`output/` now holds the packaged mod. Drop the folder into
+`<BattleShip-install>/mods/` for development, or pack it as `.o2r` for
+distribution:
+
+```bash
+cmake --build build --target mod_playertint_o2r   # inside the engine tree
+# or, standalone:
+torch pack output playertint.o2r o2r
+```
+
+## Files
+
+| File | Purpose |
+|------|---------|
+| `src/playertint.c` | The mod: registers the `FighterEnvColorQueryEvent` listener. |
+| `include/mod.h` | Author API (`MOD_INIT`/`MOD_EXIT`, `mod_log`, hooks). Same as the template. |
+| `manifest.json` | Mod metadata the loader reads. |
+| `CMakeLists.txt` | Packaging-only build (amalgamation + copy). |
+
+See [`docs/modding.md`](../../docs/modding.md) for the full event catalog and
+the other two extension mechanisms.

--- a/workspace/playertint/include/mod.h
+++ b/workspace/playertint/include/mod.h
@@ -1,0 +1,89 @@
+/*
+ * mod.h — BattleShip native C-mod author API.
+ *
+ * #include this from your mod's .c source. The TCC scripting layer
+ * compiles your source at runtime, links against BattleShip.def
+ * (auto-generated from the engine binary's export table), and calls
+ * your ModInit / ModExit entry points.
+ *
+ * Mod lifecycle:
+ *   - Engine boot loads each mod's manifest.json, compiles its sources,
+ *     resolves ModInit by name and calls it. Subscribe to events here.
+ *   - Engine shutdown / hot-reload calls ModExit. Unregister listeners
+ *     and free anything you allocated.
+ *
+ * Symbol visibility:
+ *   - HM_API marks ModInit / ModExit as exported so the engine's
+ *     dlsym/GetProcAddress finds them. Don't use HM_API on internal
+ *     helpers — `static` is preferred.
+ *
+ * Cross-mod calls:
+ *   - ScriptGetFunction(modName, "FunctionName") returns an opaque
+ *     function pointer to a symbol in another loaded mod. Use the
+ *     CALL_FUNC helper macro for the convention `<Func>Symbol` /
+ *     `<Func>Func` typedef:
+ *
+ *       #define MyFooSymbol "MyFoo"
+ *       typedef int (*MyFooFunc)(int x);
+ *       int result = CALL_FUNC("MyLib", MyFoo, 42);
+ */
+#pragma once
+
+/* The host engine is compiled with -DPORT, which selects a different
+ * layout for many decomp structs (FTAttributes, ITAttributes, etc —
+ * pointer fields collapse to u32 reloc tokens under the PORT path).
+ * Mods MUST see the same layout, otherwise field offsets shift and
+ * cross-boundary struct reads return garbage (e.g. fp->joints[joint_id]
+ * lands on random memory mid-FTAttributes). Define before any decomp
+ * header is pulled in. */
+#ifndef PORT
+#define PORT 1
+#endif
+
+#if defined(_WIN32) || defined(__CYGWIN__)
+    #define HM_API   __declspec(dllexport)
+    #define HM_IMPORT __declspec(dllimport)
+#else
+    #define HM_API    __attribute__((visibility("default")))
+    #define HM_IMPORT
+#endif
+
+#define MOD_INIT HM_API void ModInit
+#define MOD_EXIT HM_API void ModExit
+
+extern void* ScriptGetFunction(const char* module, const char* function);
+
+#define CALL_FUNC(mod, func, ...) ((func##Func)ScriptGetFunction(mod, func##Symbol))(__VA_ARGS__)
+
+/* Logging from inside a mod.
+ *
+ * mod_log(fmt, ...) routes through the engine's port_log, which writes
+ * to %APPDATA%/BattleShip/ssb64.log. Output appears immediately
+ * (port_log fflushes after every write). Format string is printf-style.
+ *
+ * In Debug builds on Windows, libultraship allocates a console at
+ * startup and redirects stdout / stderr to it, so printf works and
+ * shows up in that window. Release builds have no console, so stdout
+ * goes nowhere. mod_log works in both configurations.
+ */
+extern HM_IMPORT void port_log(const char* fmt, ...);
+#define mod_log port_log
+
+/* Hook installation + symbol resolution.
+ *
+ * mod_install_hook(symbol_name, replacement, original_out) detours the
+ * named host function in memory: calls to it now jump to `replacement`,
+ * and `*original_out` is set to a trampoline that runs the unhooked
+ * original. Returns 0 on success.
+ *
+ * mod_resolve_symbol(symbol_name) returns the address of any host
+ * symbol by name (used to call engine functions that aren't statically
+ * resolvable from the mod, e.g. when the function pointer is needed).
+ *
+ * Hooks are owned by the mod that installed them. When the mod is
+ * unloaded (engine shutdown or hot-reload), HookManager walks the
+ * mod's chain and removes each hook cleanly, so reloading a hook-
+ * installing mod is safe.
+ */
+extern HM_IMPORT int   mod_install_hook(const char* symbol_name, void* replacement, void** original_out);
+extern HM_IMPORT void* mod_resolve_symbol(const char* symbol_name);

--- a/workspace/playertint/manifest.json
+++ b/workspace/playertint/manifest.json
@@ -1,0 +1,10 @@
+{
+    "name": "Player Tint",
+    "main": "build.gen",
+    "version": "1.0.0",
+    "website": "https://example.com",
+    "description": "Gives each player a distinct fighter color via FighterEnvColorQueryEvent (P1 red, P2 blue, P3 green, P4 yellow).",
+    "author": "ssb64-port",
+    "license": "MIT",
+    "code-version": 1
+}

--- a/workspace/playertint/src/playertint.c
+++ b/workspace/playertint/src/playertint.c
@@ -1,0 +1,59 @@
+/*
+ * playertint.c — give each player a distinct fighter color.
+ *
+ * A complete, single-purpose example of the Fighter query/override event
+ * system. It subscribes to FighterEnvColorQueryEvent and, for every
+ * fighter the engine is about to draw, forces that player's environment
+ * color to a fixed per-player tint (P1 red, P2 blue, P3 green, P4 yellow).
+ * Handy for telling players apart at a glance — and a clean demonstration
+ * of a Fighter event whose payload is all primitives, so there are no
+ * decomp-struct casts to get wrong.
+ *
+ * How the event works (see port/hooks/list/FighterEvent.h):
+ *   - The engine fires FighterEnvColorQueryEvent from ftDisplayMainProcDisplay
+ *     once per fighter per frame, with `rgba` pre-filled to 0 (= "no
+ *     override, take the vanilla color").
+ *   - A listener may overwrite `rgba` with any non-zero RGBA word to force
+ *     that color instead. We do exactly that, keyed on `player`.
+ *   - With this mod unloaded the event has zero listeners and the engine
+ *     takes the vanilla path — fighters look exactly as they always did.
+ *
+ * RGBA byte order matches the guide's example (0xFF0000FF = opaque red):
+ * 0xRRGGBBAA.
+ */
+#include "mod.h"
+
+#include "port/hooks/Events.h"
+
+/* Opaque per-player tints, indexed by the 0-based player id. */
+static const uint32_t kPlayerColors[4] = {
+    0xFF0000FF, /* P1 — red    */
+    0x0000FFFF, /* P2 — blue   */
+    0x00FF00FF, /* P3 — green  */
+    0xFFFF00FF, /* P4 — yellow */
+};
+
+static ListenerID s_envColorListenerID;
+
+static void OnEnvColorQuery(IEvent* event) {
+    FighterEnvColorQueryEvent* e = (FighterEnvColorQueryEvent*)event;
+
+    /* player is 0-based; guard the index so a 5th slot (if one ever
+     * fires) falls through to the vanilla color rather than reading
+     * past the palette. */
+    if (e->player >= 0 && e->player < 4) {
+        e->rgba = kPlayerColors[e->player];
+    }
+}
+
+MOD_INIT() {
+    s_envColorListenerID = REGISTER_LISTENER(FighterEnvColorQueryEvent,
+                                             EVENT_PRIORITY_NORMAL,
+                                             OnEnvColorQuery);
+    mod_log("[PlayerTint] init OK — per-player fighter tints active\n");
+}
+
+MOD_EXIT() {
+    UNREGISTER_LISTENER(FighterEnvColorQueryEvent, s_envColorListenerID);
+    mod_log("[PlayerTint] exit OK\n");
+}


### PR DESCRIPTION
Hey! The native C mod system is honestly one of the coolest things in this project, but right now the only docs for it live as per-folder READMEs under `workspace/`. A newcomer has to go digging just to find out which events exist or how the hook system fits together.

This adds `docs/modding.md` as a proper front door. It deliberately doesn't repeat the template README (that's still the canonical authoring how-to, and I link straight to it). What it adds is the stuff that wasn't written down anywhere a modder would look:

- The three ways to extend the engine, and when to reach for each one: event listeners, function detours via `mod_install_hook`, and the fighter query/override events.
- A full event reference. Every `EngineEvent` and `FighterEvent`, where it fires, its payload, and whether it's a query, an apply, or a notify point.
- A worked example (tinting a fighter), plus the `PORT` struct-layout gotcha and the logging / hot-reload notes that bite people.

Everything is pulled straight from the shipped headers (`EngineEvent.h`, `FighterEvent.h`, and libultraship's `EventTypes.h`), so it should track the code as it stands today. Docs only, no API changes. One honest caveat: the example mod is written from the headers but I haven't run it through the runtime TCC compile, so a second pair of eyes there would be welcome.

I also linked it from the README's "Further reading" list so it's actually findable.

Thank you so much for your effort on this project, the mod system especially. It deserved a front door, and I hope this is a decent one.
